### PR TITLE
Run gitlint only if in a PR, use env vars

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -42,5 +42,5 @@ jobs:
           python-version: '3.x'
       - name: Install gitlint
         run: pip install gitlint
-      - run: gitlint --commits ${{ env.GITHUB_BASE_REF }}..${{ env.GITHUB_HEAD_REF }}
+      - run: gitlint --commits ${GITHUB_BASE_REF}..${GITHUB_HEAD_REF}
 

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -42,5 +42,5 @@ jobs:
           python-version: '3.x'
       - name: Install gitlint
         run: pip install gitlint
-      - run: gitlint --commits ${GITHUB_BASE_REF}..${GITHUB_HEAD_REF}
+      - run: gitlint --commits ${GITHUB_BASE_REF}..${GITHUB_SHA}
 

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -31,6 +31,7 @@ jobs:
         uses: kt3k/license_checker@v1.0.6
   dco-check:
     runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
     steps:
       - uses: actions/checkout@master
         with:
@@ -41,4 +42,5 @@ jobs:
           python-version: '3.x'
       - name: Install gitlint
         run: pip install gitlint
-      - run: gitlint --commits $(git merge-base origin/main HEAD)..
+      - run: gitlint --commits ${{ env.GITHUB_BASE_REF }}..${{ env.GITHUB_HEAD_REF }}
+


### PR DESCRIPTION
This patch changes the gitlint step to only run on pull requests and
then use the env.GITHUB_BASE_REF and env.GITHUB_HEAD_REF variables
instead of hacking something with git-merge-base.

Might be more robust.
