### PR TITLE
mqtt-format: no_std

### DIFF
--- a/mqtt-format/Cargo.toml
+++ b/mqtt-format/Cargo.toml
@@ -12,11 +12,15 @@ categories = ["embedded", "parsing"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-futures = "0.3.21"
-nom = "7.1.1"
+futures = { version = "0.3.21", default-features = false }
+nom = { version = "7.1.1", default-features = false }
 nom-supreme = "0.8.0"
 thiserror = "1.0.31"
 
 [dev-dependencies]
 pretty_assertions = "1.2.1"
 tokio = { version = "1.19.2", features = ["test-util", "macros"] }
+
+[features]
+default = ["std"]
+std = ["nom/std", "futures/std"]

--- a/mqtt-format/src/v3/identifier.rs
+++ b/mqtt-format/src/v3/identifier.rs
@@ -4,10 +4,13 @@
 //   file, You can obtain one at http://mozilla.org/MPL/2.0/.
 //
 
+#[cfg(feature = "std")]
 use futures::{AsyncWrite, AsyncWriteExt};
 use nom::{number::complete::be_u16, Parser};
 
-use super::{errors::MPacketWriteError, MSResult};
+#[cfg(feature = "std")]
+use super::errors::MPacketWriteError;
+use super::MSResult;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct MPacketIdentifier(pub u16);
@@ -15,7 +18,9 @@ pub struct MPacketIdentifier(pub u16);
 pub fn mpacketidentifier(input: &[u8]) -> MSResult<'_, MPacketIdentifier> {
     be_u16.map(MPacketIdentifier).parse(input)
 }
+
 impl MPacketIdentifier {
+    #[cfg(feature = "std")]
     pub(crate) async fn write_to<W: AsyncWrite>(
         &self,
         writer: &mut std::pin::Pin<&mut W>,
@@ -24,6 +29,7 @@ impl MPacketIdentifier {
         Ok(())
     }
 
+    #[cfg(feature = "std")]
     pub(crate) fn get_len(&self) -> usize {
         2
     }

--- a/mqtt-format/src/v3/packet.rs
+++ b/mqtt-format/src/v3/packet.rs
@@ -4,17 +4,23 @@
 //   file, You can obtain one at http://mozilla.org/MPL/2.0/.
 //
 
+#[cfg(feature = "std")]
 use std::pin::Pin;
 
+#[cfg(feature = "std")]
 use futures::AsyncWriteExt;
+
 use nom::{
     bits, bytes::complete::take, error::FromExternalError, number::complete::be_u16,
     sequence::tuple, IResult, Parser,
 };
 
+#[cfg(feature = "std")]
+use super::errors::MPacketWriteError;
+
 use super::{
     connect_return::{mconnectreturn, MConnectReturnCode},
-    errors::{MPacketHeaderError, MPacketWriteError},
+    errors::MPacketHeaderError,
     header::{mfixedheader, MPacketHeader, MPacketKind},
     identifier::{mpacketidentifier, MPacketIdentifier},
     qos::{mquality_of_service, MQualityOfService},
@@ -82,6 +88,7 @@ pub enum MPacket<'message> {
     Disconnect,
 }
 
+#[cfg(feature = "std")]
 impl<'message> MPacket<'message> {
     pub async fn write_to<W: futures::AsyncWrite>(
         &self,
@@ -305,6 +312,7 @@ impl<'message> MPacket<'message> {
     }
 }
 
+#[cfg(feature = "std")]
 fn bools_to_u8(bools: [bool; 8]) -> u8 {
     (bools[0] as u8) << 7
         | (bools[1] as u8) << 6

--- a/mqtt-format/src/v3/qos.rs
+++ b/mqtt-format/src/v3/qos.rs
@@ -4,9 +4,13 @@
 //   file, You can obtain one at http://mozilla.org/MPL/2.0/.
 //
 
+#[cfg(feature = "std")]
 use futures::{AsyncWrite, AsyncWriteExt};
 
-use super::errors::{MPacketHeaderError, MPacketWriteError};
+#[cfg(feature = "std")]
+use super::errors::MPacketWriteError;
+
+use super::errors::MPacketHeaderError;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MQualityOfService {
@@ -23,7 +27,9 @@ pub fn mquality_of_service(lower: u8) -> Result<MQualityOfService, MPacketHeader
         inv_qos => Err(MPacketHeaderError::InvalidQualityOfService(inv_qos)),
     }
 }
+
 impl MQualityOfService {
+    #[cfg(feature = "std")]
     pub async fn write_to<W: AsyncWrite>(
         &self,
         writer: &mut std::pin::Pin<&mut W>,

--- a/mqtt-format/src/v3/strings.rs
+++ b/mqtt-format/src/v3/strings.rs
@@ -4,10 +4,13 @@
 //   file, You can obtain one at http://mozilla.org/MPL/2.0/.
 //
 
+#[cfg(feature = "std")]
 use futures::{AsyncWrite, AsyncWriteExt};
+
 use nom::{bytes::complete::take, number::complete::be_u16, IResult, Parser};
 use nom_supreme::ParserExt;
 
+#[cfg(feature = "std")]
 use super::errors::MPacketWriteError;
 
 /// A v3 MQTT string as defined in section 1.5.3
@@ -29,6 +32,7 @@ impl<'message> MString<'message> {
         2 + mstr.value.len()
     }
 
+    #[cfg(feature = "std")]
     pub(crate) async fn write_to<W: AsyncWrite>(
         mstr: &MString<'_>,
         writer: &mut std::pin::Pin<&mut W>,
@@ -95,6 +99,7 @@ mod tests {
         )
     }
 
+    #[cfg(feature = "std")]
     #[tokio::test]
     async fn check_simple_string_roundtrip() {
         let input = [0x00, 0x05, 0x41, 0xF0, 0xAA, 0x9B, 0x94];

--- a/mqtt-format/src/v3/subscription_request.rs
+++ b/mqtt-format/src/v3/subscription_request.rs
@@ -4,12 +4,16 @@
 //   file, You can obtain one at http://mozilla.org/MPL/2.0/.
 //
 
+#[cfg(feature = "std")]
 use futures::{AsyncWrite, AsyncWriteExt};
+
 use nom::{multi::many1_count, Parser};
 use nom_supreme::ParserExt;
 
+#[cfg(feature = "std")]
+use super::errors::MPacketWriteError;
+
 use super::{
-    errors::MPacketWriteError,
     qos::{mquality_of_service, MQualityOfService},
     strings::{mstring, MString},
     MSResult,
@@ -22,6 +26,7 @@ pub struct MSubscriptionRequests<'message> {
 }
 
 impl<'message> MSubscriptionRequests<'message> {
+    #[cfg(feature = "std")]
     pub(crate) async fn write_to<W: AsyncWrite>(
         &self,
         writer: &mut std::pin::Pin<&mut W>,
@@ -29,6 +34,8 @@ impl<'message> MSubscriptionRequests<'message> {
         writer.write_all(self.data).await?;
         Ok(())
     }
+
+    #[cfg(feature = "std")]
     pub(crate) fn get_len(&self) -> usize {
         self.data.len()
     }
@@ -84,6 +91,7 @@ pub struct MSubscriptionRequest<'message> {
 }
 
 impl<'message> MSubscriptionRequest<'message> {
+    #[cfg(feature = "std")]
     pub async fn write_to<W: AsyncWrite>(
         &self,
         writer: &mut std::pin::Pin<&mut W>,


### PR DESCRIPTION
This PR transforms the `mqtt-format` subcrate into a `no_std` crate.

--- 

I'm not yet sure about the `nom-supreme` dependency. Do you have a hint?