### PR TITLE
Make bors not include details of PR message

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -1,2 +1,3 @@
 status = ["checks", "license"]
 update_base_for_deletes = true
+cut_body_after = "---"


### PR DESCRIPTION
I think this would be a good addition to the bors configuration because it makes bors ignore everything after a `---` (a seperation line in markdown).