### PR TITLE
Let bors cut after <details>

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -1,3 +1,3 @@
 status = ["checks", "license"]
 update_base_for_deletes = true
-cut_body_after = "---"
+cut_body_after = "<details>"


### PR DESCRIPTION
I did not think about dependabot when adding the cut after "---". Dependabot adds HTML in the PR title and we don't want that to be in the commit message for the merge commit, do we?

So change it to "<details>" here, which is less ergonomic for users, but way better for merging dependabot updates.
