### PR TITLE
Allow compatiblity with secondary licenses.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -365,9 +365,3 @@ file in a relevant directory) where a recipient would be likely to look
 for such a notice.
 
 You may add additional accurate notices of copyright ownership.
-
-Exhibit B - "Incompatible With Secondary Licenses" Notice
----------------------------------------------------------
-
-  This Source Code Form is "Incompatible With Secondary Licenses", as
-  defined by the Mozilla Public License, v. 2.0.


### PR DESCRIPTION
Currently our license does _not_ allow you to use our software if you are distributing it with a secondary license. This means if someone wants to use the cloudmqtt client in a GPL v2.0+ project they cannot license the whole as GPL. This patch remoes that incompatibility and would allow users to then distribute their whole project as GPL v2.0+.

Signed-off-by: Marcel Müller <neikos@neikos.email>