### PR TITLE
Add more sophisticated interface for executable calling

### DIFF
--- a/mqtt-tester/src/executable.rs
+++ b/mqtt-tester/src/executable.rs
@@ -48,8 +48,8 @@ impl ClientExecutable {
 
 pub trait ClientExecutableCommand {
     fn as_str(&self) -> &'static str;
-    fn args(&self) -> &[&'static str] {
-        &[]
+    fn args(&self) -> Vec<String> {
+        vec![]
     }
 }
 
@@ -61,9 +61,9 @@ macro_rules! define_command {
             fn as_str(&self) -> &'static str {
                 $s
             }
-            fn args(&self) -> &[&'static str] {
-                &[
-                    $($arg),+
+            fn args(&self) -> Vec<String> {
+                vec![
+                    $($arg.to_string()),+
                 ]
             }
         }

--- a/mqtt-tester/src/executable.rs
+++ b/mqtt-tester/src/executable.rs
@@ -103,3 +103,47 @@ define_command!(QuitCommand => "quit");
 define_command!(Subscribe { topic: String } => "subscribe", args: "--topic={topic}");
 define_command!(SendToTopic { topic: String, qos: u8, message: String } => "send-to-topic", args: "--topic={topic}", "--qos={qos}", "--message={message}");
 define_command!(ExpectOnTopic { topic: String, qos: u8 } => "expect-on-topic", args: "--topic={topic}", "--qos={qos}");
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_quit_command_as_string() {
+        assert_eq!("quit", QuitCommand.as_str());
+        assert!(QuitCommand.args().is_empty());
+    }
+
+    #[test]
+    fn test_subscribe_command() {
+        let command = Subscribe {
+            topic: "foo".to_string(),
+        };
+        assert_eq!("subscribe", command.as_str());
+        assert_eq!(vec!["--topic=foo".to_string()], command.args());
+    }
+
+    #[test]
+    fn test_send_to_topic_command() {
+        let command = SendToTopic {
+            topic: "foo".to_string(),
+            qos: 0,
+            message: "Message".to_string(),
+        };
+        assert_eq!("send-to-topic", command.as_str());
+        assert!(command.args().contains(&"--topic=foo".to_string()));
+        assert!(command.args().contains(&"--qos=0".to_string()));
+        assert!(command.args().contains(&"--message=Message".to_string()));
+    }
+
+    #[test]
+    fn test_expect_on_topic() {
+        let command = ExpectOnTopic {
+            topic: "foo".to_string(),
+            qos: 0,
+        };
+        assert_eq!("expect-on-topic", command.as_str());
+        assert!(command.args().contains(&"--topic=foo".to_string()));
+        assert!(command.args().contains(&"--qos=0".to_string()));
+    }
+}

--- a/mqtt-tester/src/executable.rs
+++ b/mqtt-tester/src/executable.rs
@@ -54,6 +54,24 @@ pub trait ClientExecutableCommand {
 }
 
 macro_rules! define_command {
+    ($tyname:ident { $($member:ident : $memty:ty ),+ } => $s:literal, args: $($arg:literal),+) => {
+        pub struct $tyname {
+            $(pub $member : $memty),*
+        }
+
+        impl ClientExecutableCommand for $tyname {
+            fn as_str(&self) -> &'static str {
+                $s
+            }
+            fn args(&self) -> Vec<String> {
+                $(let $member = &self.$member;)+
+
+                vec![
+                    $(format!($arg)),+
+                ]
+            }
+        }
+    };
     ($tyname:ident => $s:literal, args: $($arg:literal),+) => {
         pub struct $tyname;
 

--- a/mqtt-tester/src/executable.rs
+++ b/mqtt-tester/src/executable.rs
@@ -1,0 +1,85 @@
+//
+//   This Source Code Form is subject to the terms of the Mozilla Public
+//   License, v. 2.0. If a copy of the MPL was not distributed with this
+//   file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+
+use std::path::PathBuf;
+use std::process::Stdio;
+
+use tokio::process::Command;
+
+pub struct ClientExecutable {
+    path: PathBuf,
+}
+
+impl ClientExecutable {
+    pub fn new(path: PathBuf) -> Self {
+        Self { path }
+    }
+
+    pub fn call<I>(&self, args: I) -> miette::Result<Command>
+    where
+        I: IntoIterator<Item = Box<dyn ClientExecutableCommand>>,
+    {
+        let mut command = Command::new(&self.path);
+
+        command
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+
+        let args: Vec<_> = args
+            .into_iter()
+            .flat_map(|cec| {
+                let mut v = vec![cec.as_str().to_string()];
+                v.extend(cec.args());
+                v
+            })
+            .collect();
+
+        if !args.is_empty() {
+            command.args(args);
+        }
+
+        Ok(command)
+    }
+}
+
+pub trait ClientExecutableCommand {
+    fn as_str(&self) -> &'static str;
+    fn args(&self) -> &[&'static str] {
+        &[]
+    }
+}
+
+macro_rules! define_command {
+    ($tyname:ident => $s:literal, args: $($arg:literal),+) => {
+        pub struct $tyname;
+
+        impl ClientExecutableCommand for $tyname {
+            fn as_str(&self) -> &'static str {
+                $s
+            }
+            fn args(&self) -> &[&'static str] {
+                &[
+                    $($arg),+
+                ]
+            }
+        }
+    };
+
+    ($tyname:ident => $s:literal) => {
+        pub struct $tyname;
+
+        impl ClientExecutableCommand for $tyname {
+            fn as_str(&self) -> &'static str {
+                $s
+            }
+        }
+    }
+
+}
+
+define_command!(QuitCommand => "quit");
+define_command!(Subscribe => "subscribe", args: "topicA");

--- a/mqtt-tester/src/executable.rs
+++ b/mqtt-tester/src/executable.rs
@@ -100,4 +100,6 @@ macro_rules! define_command {
 }
 
 define_command!(QuitCommand => "quit");
-define_command!(Subscribe => "subscribe", args: "topicA");
+define_command!(Subscribe { topic: String } => "subscribe", args: "--topic={topic}");
+define_command!(SendToTopic { topic: String, qos: u8, message: String } => "send-to-topic", args: "--topic={topic}", "--qos={qos}", "--message={message}");
+define_command!(ExpectOnTopic { topic: String, qos: u8 } => "expect-on-topic", args: "--topic={topic}", "--qos={qos}");

--- a/mqtt-tester/src/main.rs
+++ b/mqtt-tester/src/main.rs
@@ -6,6 +6,7 @@
 
 mod client_report;
 mod command;
+mod executable;
 mod report;
 mod util;
 


### PR DESCRIPTION
This is the first step towards a more sophisticated interface for calling the executable that is tested.

There's a bit of code already there for specifying arguments for the executable.

My idea currently is to call the executable with commands to tell it how it should behave, for example "subscribe to topic A", "send message on topic A", "subscribe to topic B", ... etc.

This is a rough sketchup for now, but I'd like to get some feedback on it. The idea is to let the tests later specify how the executable should behave for the test but there might be also an opportunity somewhere that the tests are feeded with commands and they test their individual thing for a given procedure the executable follows...

@TheNeikos what do you think?