### PR TITLE
Test flows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -608,6 +608,7 @@ name = "mqtt-tester"
 version = "0.1.0"
 dependencies = [
  "ansi_term",
+ "async-trait",
  "bytes",
  "clap 3.2.23",
  "futures",

--- a/mqtt-tester/Cargo.toml
+++ b/mqtt-tester/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 
 [dependencies]
 ansi_term = "0.12.1"
+async-trait = "0.1.60"
 bytes = "1.1.0"
 clap = { version = "3.2.8", features = ["derive"] }
 futures = "0.3"

--- a/mqtt-tester/src/client_report.rs
+++ b/mqtt-tester/src/client_report.rs
@@ -706,10 +706,10 @@ async fn check_connect_flag_username_zero_means_password_zero(
 
 struct NoUsernameMeansNoPassword;
 impl PacketInvariant for NoUsernameMeansNoPassword {
-    fn test_invariant(&self, packet: &MPacket<'_>) -> miette::Result<Report> {
-        let result = if let MConnect {
+    fn test_invariant(&self, packet: &MPacket<'_>) -> Option<miette::Result<Report>> {
+        let result = if let MPacket::Connect(MConnect {
             username, password, ..
-        } = packet
+        }) = packet
         {
             if username.is_none() {
                 if password.is_some() {
@@ -720,13 +720,15 @@ impl PacketInvariant for NoUsernameMeansNoPassword {
             } else {
                 ReportResult::Success
             }
+        } else {
+            return None;
         };
 
-        Ok(mk_report! {
+        Some(Ok(mk_report! {
             name: "If the CONNECT packet flag for username is set, a username must be present",
             desc: "If the User Name Flag is set to 1, a user name MUST be present in the payload.",
             normative: "[MQTT-3.1.2-18, MQTT-3.1.2-19]",
             result
-        })
+        }))
     }
 }

--- a/mqtt-tester/src/command.rs
+++ b/mqtt-tester/src/command.rs
@@ -119,7 +119,7 @@ impl Output {
             Ok((_, packet)) => self
                 .attached_invariants
                 .iter()
-                .map(|inv| inv.test_invariant(&packet))
+                .flat_map(|inv| inv.test_invariant(&packet))
                 .collect::<Result<Vec<_>, _>>()
                 .map(|_| ()),
             Err(e) => {

--- a/mqtt-tester/src/command.rs
+++ b/mqtt-tester/src/command.rs
@@ -4,6 +4,8 @@
 //   file, You can obtain one at http://mozilla.org/MPL/2.0/.
 //
 
+use std::sync::Arc;
+
 use bytes::{BufMut, BytesMut};
 use miette::IntoDiagnostic;
 use mqtt_format::v3::packet::MPacket;
@@ -11,6 +13,8 @@ use tokio::{
     io::{AsyncReadExt, AsyncWriteExt},
     process::{ChildStdin, ChildStdout},
 };
+
+use crate::packet_invariant::PacketInvariant;
 
 pub struct Command {
     inner: tokio::process::Command,
@@ -27,7 +31,15 @@ impl Command {
         let mut client = self.inner.spawn().into_diagnostic()?;
         let to_client = client.stdin.take().unwrap();
         let stdout = client.stdout.take().unwrap();
-        Ok((client, Input(to_client), Output { stdout }))
+
+        Ok((
+            client,
+            Input(to_client),
+            Output {
+                stdout,
+                attached_invariants: vec![],
+            },
+        ))
     }
 }
 
@@ -54,11 +66,19 @@ impl Input {
 
 pub struct Output {
     stdout: ChildStdout,
+    attached_invariants: Vec<Arc<dyn crate::packet_invariant::PacketInvariant>>,
 }
 
 static_assertions::assert_impl_all!(Output: Send);
 
 impl Output {
+    pub fn with_invariants<I>(&mut self, i: I)
+    where
+        I: Iterator<Item = Arc<dyn PacketInvariant>>,
+    {
+        self.attached_invariants.extend(i);
+    }
+
     async fn wait_for(&mut self, expected_bytes: &[u8]) -> miette::Result<Vec<u8>> {
         let mut buf = vec![0; expected_bytes.len()];
         match tokio::time::timeout(
@@ -92,7 +112,20 @@ impl Output {
             .write_to(std::pin::Pin::new(&mut buf))
             .await
             .into_diagnostic()?;
-        self.wait_for(&buf).await.map(|_| ())
+
+        let bytes = self.wait_for(&buf).await?;
+
+        match mqtt_format::v3::packet::mpacket(&bytes) {
+            Ok((_, packet)) => self
+                .attached_invariants
+                .iter()
+                .map(|inv| inv.test_invariant(&packet))
+                .collect::<Result<Vec<_>, _>>()
+                .map(|_| ()),
+            Err(e) => {
+                miette::bail!("Failed to parse as MQTT packet: {}", e)
+            }
+        }
     }
 
     pub async fn wait_and_check(&mut self, check: CheckBytesFn) -> miette::Result<()> {

--- a/mqtt-tester/src/flow.rs
+++ b/mqtt-tester/src/flow.rs
@@ -26,22 +26,24 @@ impl Flow for WaitForConnectFlow {
 
     async fn execute(&self, _input: Input, mut output: Output) -> Result<(), miette::Error> {
         output
-            .wait_and_check(Box::new(|bytes: &[u8]| -> bool {
-                let connect_flags = if let Some(flags) = find_connect_flags(bytes) {
-                    flags
-                } else {
-                    return false;
-                };
+            .wait_and_check(
+                &(|bytes: &[u8]| -> bool {
+                    let connect_flags = if let Some(flags) = find_connect_flags(bytes) {
+                        flags
+                    } else {
+                        return false;
+                    };
 
-                let username_flag_set = 0 != (connect_flags & 0b1000_0000); // Username flag
-                let password_flag_set = 0 != (connect_flags & 0b0100_0000); // Username flag
+                    let username_flag_set = 0 != (connect_flags & 0b1000_0000); // Username flag
+                    let password_flag_set = 0 != (connect_flags & 0b0100_0000); // Username flag
 
-                if username_flag_set {
-                    !password_flag_set
-                } else {
-                    true
-                }
-            }))
+                    if username_flag_set {
+                        !password_flag_set
+                    } else {
+                        true
+                    }
+                }),
+            )
             .await
     }
 }

--- a/mqtt-tester/src/flow.rs
+++ b/mqtt-tester/src/flow.rs
@@ -1,0 +1,19 @@
+//
+//   This Source Code Form is subject to the terms of the Mozilla Public
+//   License, v. 2.0. If a copy of the MPL was not distributed with this
+//   file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+
+use crate::{
+    command::{Input, Output},
+    executable::ClientExecutableCommand,
+};
+
+#[async_trait::async_trait]
+pub trait Flow {
+    fn commands(&self) -> Vec<Box<dyn ClientExecutableCommand>>;
+    async fn execute(
+        &self,
+        command: crate::command::Command,
+    ) -> Result<std::process::Output, miette::Error>;
+}

--- a/mqtt-tester/src/flow.rs
+++ b/mqtt-tester/src/flow.rs
@@ -17,3 +17,58 @@ pub trait Flow {
         command: crate::command::Command,
     ) -> Result<std::process::Output, miette::Error>;
 }
+
+pub struct WaitForConnectFlow;
+
+#[async_trait::async_trait]
+impl Flow for WaitForConnectFlow {
+    fn commands(&self) -> Vec<Box<dyn ClientExecutableCommand>> {
+        vec![Box::new(crate::executable::QuitCommand)]
+    }
+
+    async fn execute(
+        &self,
+        command: crate::command::Command,
+    ) -> Result<std::process::Output, miette::Error> {
+        command
+            .wait_for_write([crate::command::ClientCommand::WaitAndCheck(Box::new(
+                |bytes: &[u8]| -> bool {
+                    let connect_flags = if let Some(flags) = find_connect_flags(bytes) {
+                        flags
+                    } else {
+                        return false;
+                    };
+
+                    let username_flag_set = 0 != (connect_flags & 0b1000_0000); // Username flag
+                    let password_flag_set = 0 != (connect_flags & 0b0100_0000); // Username flag
+
+                    if username_flag_set {
+                        !password_flag_set
+                    } else {
+                        true
+                    }
+                },
+            ))])
+            .await
+    }
+}
+
+fn find_connect_flags(bytes: &[u8]) -> Option<u8> {
+    macro_rules! getbyte {
+        ($n:tt) => {
+            if let Some(b) = bytes.get($n) {
+                *b
+            } else {
+                return None;
+            }
+        };
+    }
+
+    if getbyte!(0) != 0b0001_0000 {
+        return None;
+    }
+
+    let str_len = getbyte!(4);
+    let connect_flag_position = 4usize + (str_len as usize) + 2;
+    Some(getbyte!(connect_flag_position))
+}

--- a/mqtt-tester/src/flow.rs
+++ b/mqtt-tester/src/flow.rs
@@ -12,10 +12,8 @@ use crate::{
 #[async_trait::async_trait]
 pub trait Flow {
     fn commands(&self) -> Vec<Box<dyn ClientExecutableCommand>>;
-    async fn execute(
-        &self,
-        command: crate::command::Command,
-    ) -> Result<std::process::Output, miette::Error>;
+
+    async fn execute(&self, mut input: Input, mut output: Output) -> Result<(), miette::Error>;
 }
 
 pub struct WaitForConnectFlow;

--- a/mqtt-tester/src/main.rs
+++ b/mqtt-tester/src/main.rs
@@ -8,6 +8,7 @@ mod client_report;
 mod command;
 mod executable;
 mod flow;
+mod packet_invariant;
 mod report;
 
 use std::{path::PathBuf, process::exit};

--- a/mqtt-tester/src/main.rs
+++ b/mqtt-tester/src/main.rs
@@ -7,6 +7,7 @@
 mod client_report;
 mod command;
 mod executable;
+mod flow;
 mod report;
 
 use std::{path::PathBuf, process::exit};

--- a/mqtt-tester/src/packet_invariant.rs
+++ b/mqtt-tester/src/packet_invariant.rs
@@ -1,0 +1,13 @@
+//
+//   This Source Code Form is subject to the terms of the Mozilla Public
+//   License, v. 2.0. If a copy of the MPL was not distributed with this
+//   file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+
+use mqtt_format::v3::packet::MPacket;
+
+use crate::report::Report;
+
+pub trait PacketInvariant {
+    fn test_invariant(&self, packet: &MPacket<'_>) -> miette::Result<Report>;
+}

--- a/mqtt-tester/src/packet_invariant.rs
+++ b/mqtt-tester/src/packet_invariant.rs
@@ -8,6 +8,6 @@ use mqtt_format::v3::packet::MPacket;
 
 use crate::report::Report;
 
-pub trait PacketInvariant {
-    fn test_invariant(&self, packet: &MPacket<'_>) -> miette::Result<Report>;
+pub trait PacketInvariant: Send + Sync + 'static {
+    fn test_invariant(&self, packet: &MPacket<'_>) -> Option<miette::Result<Report>>;
 }


### PR DESCRIPTION
This PR implements the following scheme:

* A binary can be called and interacted with by a `Flow`. A flow implements what gets communicated. Basically a behaviour-test
* Each `Flow` gets `PacketInvariant` objects attached to its `Output`. Each invariant tests something for the packets that get send from the tested binary

Renaming things should probably happen, but I'd like to get a basic feedback first and then we'll see how to commit this cleanly and how to rename things.