### PR TITLE
Clippy deny methods/types

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -41,6 +41,11 @@
           cargoExtraArgs = "--all-features --all";
         };
 
+        mqttformatArtifacts = craneLib.buildDepsOnly {
+          inherit src;
+          cargoExtraArgs = "--all-features --all -p mqtt-format";
+        };
+
         cloudmqtt = craneLib.buildPackage {
           inherit cargoArtifacts src version;
           cargoExtraArgs = "--all-features --all";
@@ -67,6 +72,13 @@
             inherit cargoArtifacts src;
             cargoExtraArgs = "--all --all-features";
             cargoClippyExtraArgs = "-- --deny warnings";
+          };
+
+          mqtt-format-clippy = craneLib.cargoClippy {
+            inherit src;
+            cargoArtifacts = mqttformatArtifacts;
+            cargoExtraArgs = "--all --all-features -p mqtt-format";
+            cargoClippyExtraArgs = "--no-deps -p mqtt-format -- --deny warnings";
           };
 
           cloudmqtt-fmt = craneLib.cargoFmt {

--- a/mqtt-format/clippy.toml
+++ b/mqtt-format/clippy.toml
@@ -1,0 +1,10 @@
+disallowed-methods = [
+    "std::result::Result::unwrap",
+    "std::result::Result::expect",
+    "std::option::Option::unwrap",
+    "std::option::Option::expect",
+]
+
+disallowed-types = [
+    { path = "std::box::Box", reason = "No Heap allocations" },
+]

--- a/mqtt-format/src/lib.rs
+++ b/mqtt-format/src/lib.rs
@@ -4,4 +4,7 @@
 //   file, You can obtain one at http://mozilla.org/MPL/2.0/.
 //
 
+#![deny(clippy::disallowed_methods)]
+#![deny(clippy::disallowed_types)]
+
 pub mod v3;

--- a/mqtt-format/src/v3/subscription_request.rs
+++ b/mqtt-format/src/v3/subscription_request.rs
@@ -62,11 +62,15 @@ impl<'message> Iterator for MSubscriptionIter<'message> {
         }
 
         self.count -= 1;
-        let (rest, request) =
-            msubscriptionrequest(self.data).expect("Could not parse already validated sub request");
-        self.data = rest;
-
-        Some(request)
+        match msubscriptionrequest(self.data) {
+            Ok((rest, request)) => {
+                self.data = rest;
+                Some(request)
+            }
+            Err(e) => {
+                unreachable!("Could not parse already validated sub request: {}", e)
+            }
+        }
     }
 }
 

--- a/mqtt-format/src/v3/unsubscription_request.rs
+++ b/mqtt-format/src/v3/unsubscription_request.rs
@@ -45,11 +45,15 @@ impl<'message> Iterator for MUnsubscriptionIter<'message> {
         }
 
         self.count -= 1;
-        let (rest, request) = munsubscriptionrequest(self.data)
-            .expect("Could not parse already validated sub request");
-        self.data = rest;
-
-        Some(request)
+        match munsubscriptionrequest(self.data) {
+            Ok((rest, request)) => {
+                self.data = rest;
+                Some(request)
+            }
+            Err(e) => {
+                unreachable!("Could not parse already validated sub request: {}", e)
+            }
+        }
     }
 }
 


### PR DESCRIPTION
These patches makes clippy deny certain methods and types in the `mqtt-format` crate.