### PR TITLE
Fix gitlint configuration: Disallow cleanup commits

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -30,10 +30,4 @@ jobs:
       - name: Install gitlint
         run: pip install gitlint
       - run: gitlint --commits $(git merge-base origin/main HEAD)..
-  fixup-check:
-    runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
-    steps:
-      - uses: actions/checkout@v3.3.0
-      - uses: 13rac1/block-fixup-merge-action@v2.0.0
 

--- a/.gitlint
+++ b/.gitlint
@@ -38,7 +38,7 @@ ignore-merge-commits=true
 
 # Enable community contributed rules
 # See http://jorisroovers.github.io/gitlint/contrib_rules for details
-contrib=CC1
+contrib=CC1, CC2
 
 # Set the extra-path where gitlint will search for user defined rules
 # See http://jorisroovers.github.io/gitlint/user_defined_rules for details
@@ -133,4 +133,6 @@ regex=(.*)dependabot(.*)|github-actions\[bot\]
 # Specify allowed commit types. For details see: https://www.conventionalcommits.org/
 # types = bugfix,user-story,epic
 [contrib-body-requires-signed-off-by]
+
+[contrib-disallow-cleanup-commits]
 

--- a/.gitlint
+++ b/.gitlint
@@ -14,7 +14,7 @@ ignore=body-is-missing
 # verbosity should be a value between 1 and 3, the commandline -v flags take precedence over this
 # verbosity = 2
 
-# By default gitlint will ignore merge, revert, fixup and squash commits. 
+# By default gitlint will ignore merge, revert, fixup and squash commits.
 ignore-merge-commits=true
 # ignore-revert-commits=true
 # ignore-fixup-commits=true
@@ -23,7 +23,7 @@ ignore-merge-commits=true
 # Ignore any data send to gitlint via stdin
 # ignore-stdin=true
 
-# Fetch additional meta-data from the local repository when manually passing a 
+# Fetch additional meta-data from the local repository when manually passing a
 # commit message to gitlint via stdin or --commit-msg. Disabled by default.
 # staged=true
 

--- a/bors.toml
+++ b/bors.toml
@@ -12,7 +12,6 @@ pr_status = [
     # Github Actions
     "license",
     "dco-check",
-    "fixup-check",
 ]
 update_base_for_deletes = true
 cut_body_after = "<details>"


### PR DESCRIPTION
Found that gitlint isn't properly configured, so I fixed it in this PR.

This PR also removes the fixup-check CI job, as gitlint does check this with the new configuration.