### PR TITLE
Command seperation

### DIFF
--- a/mqtt-tester/src/behaviour/wait_for_connect.rs
+++ b/mqtt-tester/src/behaviour/wait_for_connect.rs
@@ -16,7 +16,7 @@ pub struct WaitForConnect;
 #[async_trait::async_trait]
 impl BehaviourTest for WaitForConnect {
     fn commands(&self) -> Vec<Box<dyn ClientExecutableCommand>> {
-        vec![Box::new(crate::executable::QuitCommand)]
+        vec![]
     }
 
     async fn execute(&self, _input: Input, mut output: Output) -> Result<(), miette::Error> {

--- a/mqtt-tester/src/executable.rs
+++ b/mqtt-tester/src/executable.rs
@@ -31,6 +31,7 @@ impl ClientExecutable {
             .flat_map(|cec| {
                 let mut v = vec![cec.as_str().to_string()];
                 v.extend(cec.args());
+                v.push("----".to_string());
                 v
             })
             .collect();

--- a/src/bin/cloudmqtt-test-client.rs
+++ b/src/bin/cloudmqtt-test-client.rs
@@ -9,7 +9,13 @@ use std::process::exit;
 use clap::Parser;
 use cloudmqtt::{client::MqttClient, client::MqttConnectionParams};
 use futures::StreamExt;
-use mqtt_format::v3::will::MLastWill;
+use mqtt_format::v3::{
+    packet::{MPacket, MPublish},
+    qos::MQualityOfService,
+    strings::MString,
+    subscription_request::MSubscriptionRequest,
+    will::MLastWill,
+};
 
 fn print_error_and_quit(e: String) -> ! {
     eprintln!("{}", e);
@@ -86,14 +92,61 @@ async fn main() {
     let packet_stream = client.build_packet_stream().build();
     let mut packet_stream = Box::pin(packet_stream.stream());
 
-    loop {
-        let _packet = match packet_stream.next().await {
-            Some(Ok(packet)) => packet,
-            None => {
-                eprintln!("Stream ended, stopping");
-                break;
+    for arg in args {
+        match arg.command {
+            Command::Quit => {}
+            Command::Subscribe { topic } => {
+                let subscription_requests = [MSubscriptionRequest {
+                    topic: MString { value: &topic },
+                    qos: MQualityOfService::AtMostOnce, // TODO
+                }];
+                client.subscribe(&subscription_requests).await.unwrap();
             }
-            Some(Err(error)) => print_error_and_quit(format!("Stream errored: {error}")),
-        };
+            Command::SendToTopic {
+                topic: _,
+                qos: _,
+                message: _,
+            } => {
+                unimplemented!()
+            }
+            Command::ExpectOnTopic {
+                topic: expected_topic,
+                qos: expected_qos,
+            } => {
+                let packet = match packet_stream.next().await {
+                    Some(Ok(packet)) => packet,
+                    None => {
+                        eprintln!("Stream ended, stopping");
+                        break;
+                    }
+                    Some(Err(error)) => print_error_and_quit(format!("Stream errored: {error}")),
+                };
+
+                if let MPacket::Publish(MPublish {
+                    qos, topic_name, ..
+                }) = packet.get_packet()
+                {
+                    if topic_name.value != expected_topic {
+                        eprintln!(
+                            "Expected Publish on topic {}, got on {}",
+                            expected_topic, topic_name.value
+                        );
+                        break;
+                    }
+                    if qos.to_byte() != expected_qos {
+                        eprintln!(
+                            "Expected Publish with QoS {}, got {}",
+                            expected_qos,
+                            qos.to_byte()
+                        );
+                        break;
+                    }
+                    // all ok
+                } else {
+                    eprintln!("Expected Publish, got {:?}", packet.get_packet());
+                    break;
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
This is extracted from #133 for making that PR smaller.

These patches allow passing multiple commands to a testing binary.