### PR TITLE
Add loop at end of main()

### DIFF
--- a/src/bin/cloudmqtt-test-client.rs
+++ b/src/bin/cloudmqtt-test-client.rs
@@ -149,4 +149,15 @@ async fn main() {
             }
         }
     }
+
+    loop {
+        let _packet = match packet_stream.next().await {
+            Some(Ok(packet)) => packet,
+            None => {
+                eprintln!("Stream ended, stopping");
+                break;
+            }
+            Some(Err(error)) => print_error_and_quit(format!("Stream errored: {error}")),
+        };
+    }
 }


### PR DESCRIPTION
Extracted from #133.

This is necessary to keep the default-behaviour of the executable if no commands are passed.
