### PR TITLE
Fix argparsing in test client binary

### DIFF
--- a/src/bin/cloudmqtt-test-client.rs
+++ b/src/bin/cloudmqtt-test-client.rs
@@ -47,13 +47,6 @@ enum Command {
 
 #[tokio::main]
 async fn main() {
-    let (client_duplex, server_duplex) = tokio::io::duplex(512);
-
-    let (mut read_dup, mut write_dup) = tokio::io::split(server_duplex);
-
-    tokio::spawn(async move { tokio::io::copy(&mut tokio::io::stdin(), &mut write_dup).await });
-    tokio::spawn(async move { tokio::io::copy(&mut read_dup, &mut tokio::io::stdout()).await });
-
     let args = {
         std::env::args()
             .skip(1)
@@ -63,6 +56,13 @@ async fn main() {
             .collect::<Result<Vec<Args>, _>>()
             .expect("Parsing Arguments failed")
     };
+
+    let (client_duplex, server_duplex) = tokio::io::duplex(512);
+
+    let (mut read_dup, mut write_dup) = tokio::io::split(server_duplex);
+
+    tokio::spawn(async move { tokio::io::copy(&mut tokio::io::stdin(), &mut write_dup).await });
+    tokio::spawn(async move { tokio::io::copy(&mut read_dup, &mut tokio::io::stdout()).await });
 
     let client = MqttClient::connect_v3_duplex(
         client_duplex,

--- a/src/bin/cloudmqtt-test-client.rs
+++ b/src/bin/cloudmqtt-test-client.rs
@@ -48,13 +48,19 @@ enum Command {
 #[tokio::main]
 async fn main() {
     let args = {
-        std::env::args()
+        match std::env::args()
             .skip(1)
             .collect::<String>()
             .split("----")
             .map(|els| Args::try_parse_from(els.split(' ')))
             .collect::<Result<Vec<Args>, _>>()
-            .expect("Parsing Arguments failed")
+        {
+            Ok(args) => args,
+            Err(e) => {
+                eprintln!("{}", e);
+                exit(1)
+            }
+        }
     };
 
     let (client_duplex, server_duplex) = tokio::io::duplex(512);

--- a/src/bin/cloudmqtt-test-client.rs
+++ b/src/bin/cloudmqtt-test-client.rs
@@ -25,7 +25,7 @@ fn print_error_and_quit(e: String) -> ! {
 #[derive(clap::Parser, Debug)]
 struct Args {
     #[command(subcommand)]
-    command: Command,
+    command: Option<Command>,
 }
 
 #[derive(clap::Subcommand, Debug)]
@@ -100,25 +100,25 @@ async fn main() {
 
     for arg in args {
         match arg.command {
-            Command::Quit => {}
-            Command::Subscribe { topic } => {
+            Some(Command::Quit) => {}
+            Some(Command::Subscribe { topic }) => {
                 let subscription_requests = [MSubscriptionRequest {
                     topic: MString { value: &topic },
                     qos: MQualityOfService::AtMostOnce, // TODO
                 }];
                 client.subscribe(&subscription_requests).await.unwrap();
             }
-            Command::SendToTopic {
+            Some(Command::SendToTopic {
                 topic: _,
                 qos: _,
                 message: _,
-            } => {
+            }) => {
                 unimplemented!()
             }
-            Command::ExpectOnTopic {
+            Some(Command::ExpectOnTopic {
                 topic: expected_topic,
                 qos: expected_qos,
-            } => {
+            }) => {
                 let packet = match packet_stream.next().await {
                     Some(Ok(packet)) => packet,
                     None => {
@@ -152,6 +152,10 @@ async fn main() {
                     eprintln!("Expected Publish, got {:?}", packet.get_packet());
                     break;
                 }
+            }
+
+            None => {
+                // no command, doing nothing
             }
         }
     }


### PR DESCRIPTION
Extracted from #133.

This patchset contains fixes for the test client binary argparsing code.