### PR TITLE
Let PacketStream end on EOF on first byte

### DIFF
--- a/src/packet_stream.rs
+++ b/src/packet_stream.rs
@@ -113,7 +113,11 @@ impl<'client, ACK: AckHandler> PacketStream<'client, ACK> {
                         None => return Err(MqttError::ConnectionClosed),
                     };
 
-                    crate::read_one_packet(client_stream).await?
+                    match crate::read_one_packet(client_stream).await {
+                        Err(crate::PacketIOError::EofOnFirstByte) => return Ok(None),
+                        Err(other) => return Err(MqttError::from(other)),
+                        Ok(msg) => msg,
+                    }
                 };
 
                 let packet = next_message.get_packet();


### PR DESCRIPTION
Extracted from #133 

This patch changes the implementation of the PacketStream to automatically end iff reading the first byte from the connection results in an EOF.

This is done by extending the PacketIOError with a EofOnFirstByte that is matched against in the Stream for PacketStream impl.