### PR TITLE
Rustfmt: no grouping

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -28,13 +28,17 @@
 
         rustTarget = pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
         unstableRustTarget = pkgs.rust-bin.selectLatestNightlyWith (toolchain: toolchain.default.override {
-          extensions = [ "rust-src" "miri" ];
+          extensions = [ "rust-src" "miri" "rustfmt" ];
         });
         craneLib = (crane.mkLib pkgs).overrideToolchain rustTarget;
 
         tomlInfo = craneLib.crateNameFromCargoToml { cargoToml = ./Cargo.toml; };
         inherit (tomlInfo) pname version;
         src = ./.;
+
+        rustfmt' = pkgs.writeShellScriptBin "rustfmt" ''
+          exec "${unstableRustTarget}/bin/rustfmt" "$@"
+        '';
 
         cargoArtifacts = craneLib.buildDepsOnly {
           inherit src;
@@ -110,6 +114,7 @@
           buildInputs = [ ];
 
           nativeBuildInputs = [
+            rustfmt'
             rustTarget
 
             pkgs.cargo-msrv

--- a/mqtt-format/src/v3/connect_return.rs
+++ b/mqtt-format/src/v3/connect_return.rs
@@ -6,7 +6,8 @@
 
 use nom::error::FromExternalError;
 
-use super::{errors::MPacketHeaderError, MSResult};
+use super::errors::MPacketHeaderError;
+use super::MSResult;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]

--- a/mqtt-format/src/v3/header.rs
+++ b/mqtt-format/src/v3/header.rs
@@ -4,19 +4,19 @@
 //   file, You can obtain one at http://mozilla.org/MPL/2.0/.
 //
 
-use nom::{
-    bits,
-    bytes::complete::take_while_m_n,
-    error::{Error, ErrorKind, FromExternalError},
-    sequence::tuple,
-    IResult, Parser,
-};
+use nom::bits;
+use nom::bytes::complete::take_while_m_n;
+use nom::error::Error;
+use nom::error::ErrorKind;
+use nom::error::FromExternalError;
+use nom::sequence::tuple;
+use nom::IResult;
+use nom::Parser;
 use nom_supreme::ParserExt;
 
-use super::{
-    errors::MPacketHeaderError,
-    qos::{mquality_of_service, MQualityOfService},
-};
+use super::errors::MPacketHeaderError;
+use super::qos::mquality_of_service;
+use super::qos::MQualityOfService;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct MPacketHeader {
@@ -155,12 +155,12 @@ pub fn mfixedheader(input: &[u8]) -> IResult<&[u8], MPacketHeader> {
 
 #[cfg(test)]
 mod tests {
-    use crate::v3::{
-        header::{MPacketHeader, MPacketKind},
-        qos::MQualityOfService,
-    };
-
-    use super::{decode_variable_length, mfixedheader, mpacketkind};
+    use super::decode_variable_length;
+    use super::mfixedheader;
+    use super::mpacketkind;
+    use crate::v3::header::MPacketHeader;
+    use crate::v3::header::MPacketKind;
+    use crate::v3::qos::MQualityOfService;
 
     #[test]
     fn check_variable_length_decoding() {

--- a/mqtt-format/src/v3/identifier.rs
+++ b/mqtt-format/src/v3/identifier.rs
@@ -4,10 +4,13 @@
 //   file, You can obtain one at http://mozilla.org/MPL/2.0/.
 //
 
-use futures::{AsyncWrite, AsyncWriteExt};
-use nom::{number::complete::be_u16, Parser};
+use futures::AsyncWrite;
+use futures::AsyncWriteExt;
+use nom::number::complete::be_u16;
+use nom::Parser;
 
-use super::{errors::MPacketWriteError, MSResult};
+use super::errors::MPacketWriteError;
+use super::MSResult;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct MPacketIdentifier(pub u16);

--- a/mqtt-format/src/v3/packet.rs
+++ b/mqtt-format/src/v3/packet.rs
@@ -8,24 +8,35 @@
 use std::pin::Pin;
 
 use futures::AsyncWriteExt;
-use nom::{
-    bits, bytes::complete::take, error::FromExternalError, number::complete::be_u16,
-    sequence::tuple, IResult, Parser,
-};
+use nom::bits;
+use nom::bytes::complete::take;
+use nom::error::FromExternalError;
+use nom::number::complete::be_u16;
+use nom::sequence::tuple;
+use nom::IResult;
+use nom::Parser;
 
-use super::{
-    connect_return::{mconnectreturn, MConnectReturnCode},
-    errors::{MPacketHeaderError, MPacketWriteError},
-    header::{mfixedheader, MPacketHeader, MPacketKind},
-    identifier::{mpacketidentifier, MPacketIdentifier},
-    qos::{mquality_of_service, MQualityOfService},
-    strings::{mstring, MString},
-    subscription_acks::{msubscriptionacks, MSubscriptionAcks},
-    subscription_request::{msubscriptionrequests, MSubscriptionRequests},
-    unsubscription_request::{munsubscriptionrequests, MUnsubscriptionRequests},
-    will::MLastWill,
-    MSResult,
-};
+use super::connect_return::mconnectreturn;
+use super::connect_return::MConnectReturnCode;
+use super::errors::MPacketHeaderError;
+use super::errors::MPacketWriteError;
+use super::header::mfixedheader;
+use super::header::MPacketHeader;
+use super::header::MPacketKind;
+use super::identifier::mpacketidentifier;
+use super::identifier::MPacketIdentifier;
+use super::qos::mquality_of_service;
+use super::qos::MQualityOfService;
+use super::strings::mstring;
+use super::strings::MString;
+use super::subscription_acks::msubscriptionacks;
+use super::subscription_acks::MSubscriptionAcks;
+use super::subscription_request::msubscriptionrequests;
+use super::subscription_request::MSubscriptionRequests;
+use super::unsubscription_request::munsubscriptionrequests;
+use super::unsubscription_request::MUnsubscriptionRequests;
+use super::will::MLastWill;
+use super::MSResult;
 
 #[cfg_attr(feature = "yoke", derive(yoke::Yokeable))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -773,16 +784,16 @@ pub fn mpacket(input: &[u8]) -> MSResult<'_, MPacket<'_>> {
 
 #[cfg(test)]
 mod tests {
-    use crate::v3::{
-        packet::{MConnect, MDisconnect, MPacket},
-        strings::MString,
-        will::MLastWill,
-    };
-
-    use super::mpacket;
     use std::pin::Pin;
 
     use pretty_assertions::assert_eq;
+
+    use super::mpacket;
+    use crate::v3::packet::MConnect;
+    use crate::v3::packet::MDisconnect;
+    use crate::v3::packet::MPacket;
+    use crate::v3::strings::MString;
+    use crate::v3::will::MLastWill;
 
     #[test]
     fn check_complete_length() {

--- a/mqtt-format/src/v3/qos.rs
+++ b/mqtt-format/src/v3/qos.rs
@@ -4,9 +4,11 @@
 //   file, You can obtain one at http://mozilla.org/MPL/2.0/.
 //
 
-use futures::{AsyncWrite, AsyncWriteExt};
+use futures::AsyncWrite;
+use futures::AsyncWriteExt;
 
-use super::errors::{MPacketHeaderError, MPacketWriteError};
+use super::errors::MPacketHeaderError;
+use super::errors::MPacketWriteError;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum MQualityOfService {

--- a/mqtt-format/src/v3/strings.rs
+++ b/mqtt-format/src/v3/strings.rs
@@ -4,8 +4,12 @@
 //   file, You can obtain one at http://mozilla.org/MPL/2.0/.
 //
 
-use futures::{AsyncWrite, AsyncWriteExt};
-use nom::{bytes::complete::take, number::complete::be_u16, IResult, Parser};
+use futures::AsyncWrite;
+use futures::AsyncWriteExt;
+use nom::bytes::complete::take;
+use nom::number::complete::be_u16;
+use nom::IResult;
+use nom::Parser;
 use nom_supreme::ParserExt;
 
 use super::errors::MPacketWriteError;
@@ -72,7 +76,8 @@ pub fn mstring(input: &[u8]) -> IResult<&[u8], MString<'_>> {
 mod tests {
     use std::pin::Pin;
 
-    use super::{mstring, MString};
+    use super::mstring;
+    use super::MString;
 
     // TODO(neikos): Unclear how MQTT-1.5.3-3 is to be tested. Since we don't touch the stream, I
     // think we are fulfilling that requirement

--- a/mqtt-format/src/v3/subscription_acks.rs
+++ b/mqtt-format/src/v3/subscription_acks.rs
@@ -4,13 +4,14 @@
 //   file, You can obtain one at http://mozilla.org/MPL/2.0/.
 //
 
-use futures::{AsyncWrite, AsyncWriteExt};
-use nom::{error::FromExternalError, multi::many1_count};
+use futures::AsyncWrite;
+use futures::AsyncWriteExt;
+use nom::error::FromExternalError;
+use nom::multi::many1_count;
 
-use super::{
-    errors::{MPacketHeaderError, MPacketWriteError},
-    MSResult,
-};
+use super::errors::MPacketHeaderError;
+use super::errors::MPacketWriteError;
+use super::MSResult;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct MSubscriptionAcks<'message> {
@@ -85,9 +86,8 @@ pub fn msubscriptionacks<'message>(
 
 #[cfg(test)]
 mod tests {
-    use crate::v3::subscription_acks::MSubscriptionAck;
-
     use super::msubscriptionacks;
+    use crate::v3::subscription_acks::MSubscriptionAck;
 
     #[test]
     fn check_valid_subacks() {

--- a/mqtt-format/src/v3/subscription_request.rs
+++ b/mqtt-format/src/v3/subscription_request.rs
@@ -4,16 +4,18 @@
 //   file, You can obtain one at http://mozilla.org/MPL/2.0/.
 //
 
-use futures::{AsyncWrite, AsyncWriteExt};
-use nom::{multi::many1_count, Parser};
+use futures::AsyncWrite;
+use futures::AsyncWriteExt;
+use nom::multi::many1_count;
+use nom::Parser;
 use nom_supreme::ParserExt;
 
-use super::{
-    errors::MPacketWriteError,
-    qos::{mquality_of_service, MQualityOfService},
-    strings::{mstring, MString},
-    MSResult,
-};
+use super::errors::MPacketWriteError;
+use super::qos::mquality_of_service;
+use super::qos::MQualityOfService;
+use super::strings::mstring;
+use super::strings::MString;
+use super::MSResult;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct MSubscriptionRequests<'message> {
@@ -110,9 +112,9 @@ pub fn msubscriptionrequest(input: &[u8]) -> MSResult<'_, MSubscriptionRequest<'
 
 #[cfg(test)]
 mod tests {
-    use crate::v3::{strings::MString, subscription_request::MSubscriptionRequest};
-
     use super::msubscriptionrequests;
+    use crate::v3::strings::MString;
+    use crate::v3::subscription_request::MSubscriptionRequest;
 
     #[test]
     fn test_subscription_iterator() {

--- a/mqtt-format/src/v3/unsubscription_request.rs
+++ b/mqtt-format/src/v3/unsubscription_request.rs
@@ -4,12 +4,12 @@
 //   file, You can obtain one at http://mozilla.org/MPL/2.0/.
 //
 
-use nom::{multi::many1_count, Parser};
+use nom::multi::many1_count;
+use nom::Parser;
 
-use super::{
-    strings::{mstring, MString},
-    MSResult,
-};
+use super::strings::mstring;
+use super::strings::MString;
+use super::MSResult;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct MUnsubscriptionRequests<'message> {

--- a/mqtt-format/src/v3/will.rs
+++ b/mqtt-format/src/v3/will.rs
@@ -4,7 +4,8 @@
 //   file, You can obtain one at http://mozilla.org/MPL/2.0/.
 //
 
-use super::{qos::MQualityOfService, strings::MString};
+use super::qos::MQualityOfService;
+use super::strings::MString;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct MLastWill<'message> {

--- a/mqtt-format/src/v5/bytes.rs
+++ b/mqtt-format/src/v5/bytes.rs
@@ -4,7 +4,9 @@
 //   file, You can obtain one at http://mozilla.org/MPL/2.0/.
 //
 
-use winnow::{binary::length_take, Bytes, Parser};
+use winnow::binary::length_take;
+use winnow::Bytes;
+use winnow::Parser;
 
 use super::MResult;
 

--- a/mqtt-format/src/v5/fixed_header.rs
+++ b/mqtt-format/src/v5/fixed_header.rs
@@ -4,11 +4,13 @@
 //   file, You can obtain one at http://mozilla.org/MPL/2.0/.
 //
 
-use winnow::{
-    binary::bits::bits,
-    error::{ErrMode, FromExternalError, InputError, ParserError},
-    Bytes, Parser,
-};
+use winnow::binary::bits::bits;
+use winnow::error::ErrMode;
+use winnow::error::FromExternalError;
+use winnow::error::InputError;
+use winnow::error::ParserError;
+use winnow::Bytes;
+use winnow::Parser;
 
 use super::MResult;
 

--- a/mqtt-format/src/v5/integers.rs
+++ b/mqtt-format/src/v5/integers.rs
@@ -4,7 +4,10 @@
 //   file, You can obtain one at http://mozilla.org/MPL/2.0/.
 //
 
-use winnow::{combinator::trace, token::take_while, Bytes, Parser};
+use winnow::combinator::trace;
+use winnow::token::take_while;
+use winnow::Bytes;
+use winnow::Parser;
 
 use super::MResult;
 
@@ -47,7 +50,9 @@ pub fn parse_variable_u32(input: &mut &Bytes) -> MResult<u32> {
 mod tests {
     use winnow::Bytes;
 
-    use crate::v5::integers::{parse_u16, parse_u32, parse_variable_u32};
+    use crate::v5::integers::parse_u16;
+    use crate::v5::integers::parse_u32;
+    use crate::v5::integers::parse_variable_u32;
 
     #[test]
     fn check_integer_parsing() {

--- a/mqtt-format/src/v5/level.rs
+++ b/mqtt-format/src/v5/level.rs
@@ -4,7 +4,8 @@
 //   file, You can obtain one at http://mozilla.org/MPL/2.0/.
 //
 
-use winnow::error::{ErrMode, ParserError};
+use winnow::error::ErrMode;
+use winnow::error::ParserError;
 use winnow::Bytes;
 
 use super::MResult;

--- a/mqtt-format/src/v5/packets/auth.rs
+++ b/mqtt-format/src/v5/packets/auth.rs
@@ -6,10 +6,11 @@
 
 use winnow::Bytes;
 
-use crate::v5::{
-    variable_header::{AuthenticationData, AuthenticationMethod, ReasonString, UserProperties},
-    MResult,
-};
+use crate::v5::variable_header::AuthenticationData;
+use crate::v5::variable_header::AuthenticationMethod;
+use crate::v5::variable_header::ReasonString;
+use crate::v5::variable_header::UserProperties;
+use crate::v5::MResult;
 
 crate::v5::reason_code::make_combined_reason_code! {
     pub enum AuthReasonCode {

--- a/mqtt-format/src/v5/packets/connack.rs
+++ b/mqtt-format/src/v5/packets/connack.rs
@@ -4,22 +4,31 @@
 //   file, You can obtain one at http://mozilla.org/MPL/2.0/.
 //
 
-use winnow::{
-    error::{ErrMode, InputError, ParserError},
-    Bytes, Parser,
-};
+use winnow::error::ErrMode;
+use winnow::error::InputError;
+use winnow::error::ParserError;
+use winnow::Bytes;
+use winnow::Parser;
 
-use crate::v5::{
-    properties::define_properties,
-    variable_header::{
-        AssignedClientIdentifier, AuthenticationData, AuthenticationMethod, MaximumPacketSize,
-        MaximumQoS, ReasonString, ReceiveMaximum, ResponseInformation, RetainAvailable,
-        ServerKeepAlive, ServerReference, SessionExpiryInterval, SharedSubscriptionAvailable,
-        SubscriptionIdentifiersAvailable, TopicAliasMaximum, UserProperties,
-        WildcardSubscriptionAvailable,
-    },
-    MResult,
-};
+use crate::v5::properties::define_properties;
+use crate::v5::variable_header::AssignedClientIdentifier;
+use crate::v5::variable_header::AuthenticationData;
+use crate::v5::variable_header::AuthenticationMethod;
+use crate::v5::variable_header::MaximumPacketSize;
+use crate::v5::variable_header::MaximumQoS;
+use crate::v5::variable_header::ReasonString;
+use crate::v5::variable_header::ReceiveMaximum;
+use crate::v5::variable_header::ResponseInformation;
+use crate::v5::variable_header::RetainAvailable;
+use crate::v5::variable_header::ServerKeepAlive;
+use crate::v5::variable_header::ServerReference;
+use crate::v5::variable_header::SessionExpiryInterval;
+use crate::v5::variable_header::SharedSubscriptionAvailable;
+use crate::v5::variable_header::SubscriptionIdentifiersAvailable;
+use crate::v5::variable_header::TopicAliasMaximum;
+use crate::v5::variable_header::UserProperties;
+use crate::v5::variable_header::WildcardSubscriptionAvailable;
+use crate::v5::MResult;
 
 crate::v5::reason_code::make_combined_reason_code! {
     pub enum ConnectReasonCode {

--- a/mqtt-format/src/v5/packets/connect.rs
+++ b/mqtt-format/src/v5/packets/connect.rs
@@ -4,25 +4,33 @@
 //   file, You can obtain one at http://mozilla.org/MPL/2.0/.
 //
 
-use winnow::{
-    error::{ErrMode, InputError, ParserError},
-    Bytes, Parser,
-};
+use winnow::error::ErrMode;
+use winnow::error::InputError;
+use winnow::error::ParserError;
+use winnow::Bytes;
+use winnow::Parser;
 
-use crate::v5::{
-    bytes::parse_binary_data,
-    fixed_header::QualityOfService,
-    integers::parse_u16,
-    level::ProtocolLevel,
-    strings::parse_string,
-    variable_header::{
-        AuthenticationData, AuthenticationMethod, ContentType, CorrelationData, MaximumPacketSize,
-        MessageExpiryInterval, PayloadFormatIndicator, ReceiveMaximum, RequestProblemInformation,
-        RequestResponseInformation, ResponseTopic, SessionExpiryInterval, TopicAliasMaximum,
-        UserProperties, WillDelayInterval,
-    },
-    MResult,
-};
+use crate::v5::bytes::parse_binary_data;
+use crate::v5::fixed_header::QualityOfService;
+use crate::v5::integers::parse_u16;
+use crate::v5::level::ProtocolLevel;
+use crate::v5::strings::parse_string;
+use crate::v5::variable_header::AuthenticationData;
+use crate::v5::variable_header::AuthenticationMethod;
+use crate::v5::variable_header::ContentType;
+use crate::v5::variable_header::CorrelationData;
+use crate::v5::variable_header::MaximumPacketSize;
+use crate::v5::variable_header::MessageExpiryInterval;
+use crate::v5::variable_header::PayloadFormatIndicator;
+use crate::v5::variable_header::ReceiveMaximum;
+use crate::v5::variable_header::RequestProblemInformation;
+use crate::v5::variable_header::RequestResponseInformation;
+use crate::v5::variable_header::ResponseTopic;
+use crate::v5::variable_header::SessionExpiryInterval;
+use crate::v5::variable_header::TopicAliasMaximum;
+use crate::v5::variable_header::UserProperties;
+use crate::v5::variable_header::WillDelayInterval;
+use crate::v5::MResult;
 
 #[derive(Debug)]
 pub struct MConnect<'i> {

--- a/mqtt-format/src/v5/packets/disconnect.rs
+++ b/mqtt-format/src/v5/packets/disconnect.rs
@@ -4,13 +4,15 @@
 //   file, You can obtain one at http://mozilla.org/MPL/2.0/.
 //
 
-use winnow::{Bytes, Parser};
+use winnow::Bytes;
+use winnow::Parser;
 
-use crate::v5::{
-    properties::define_properties,
-    variable_header::{ReasonString, ServerReference, SessionExpiryInterval, UserProperties},
-    MResult,
-};
+use crate::v5::properties::define_properties;
+use crate::v5::variable_header::ReasonString;
+use crate::v5::variable_header::ServerReference;
+use crate::v5::variable_header::SessionExpiryInterval;
+use crate::v5::variable_header::UserProperties;
+use crate::v5::MResult;
 
 crate::v5::reason_code::make_combined_reason_code! {
     pub enum DisconnectReasonCode {

--- a/mqtt-format/src/v5/packets/mod.rs
+++ b/mqtt-format/src/v5/packets/mod.rs
@@ -4,19 +4,27 @@
 //   file, You can obtain one at http://mozilla.org/MPL/2.0/.
 //
 
-use self::{
-    auth::MAuth, connect::MConnect, disconnect::MDisconnect, pingreq::MPingreq,
-    pingresp::MPingresp, puback::MPuback, pubcomp::MPubcomp, publish::MPublish, pubrec::MPubrec,
-    pubrel::MPubrel, suback::MSuback, subscribe::MSubscribe, unsuback::MUnsuback,
-    unsubscribe::MUnsubscribe,
-};
-use crate::v5::fixed_header::MFixedHeader;
-use crate::v5::packets::connack::MConnack;
-use crate::v5::MResult;
 use winnow::Bytes;
 use winnow::Parser;
 
+use self::auth::MAuth;
+use self::connect::MConnect;
+use self::disconnect::MDisconnect;
+use self::pingreq::MPingreq;
+use self::pingresp::MPingresp;
+use self::puback::MPuback;
+use self::pubcomp::MPubcomp;
+use self::publish::MPublish;
+use self::pubrec::MPubrec;
+use self::pubrel::MPubrel;
+use self::suback::MSuback;
+use self::subscribe::MSubscribe;
+use self::unsuback::MUnsuback;
+use self::unsubscribe::MUnsubscribe;
 use super::fixed_header::PacketType;
+use crate::v5::fixed_header::MFixedHeader;
+use crate::v5::packets::connack::MConnack;
+use crate::v5::MResult;
 
 pub mod auth;
 pub mod connack;

--- a/mqtt-format/src/v5/packets/pingreq.rs
+++ b/mqtt-format/src/v5/packets/pingreq.rs
@@ -4,7 +4,8 @@
 //   file, You can obtain one at http://mozilla.org/MPL/2.0/.
 //
 
-use winnow::{Bytes, Parser};
+use winnow::Bytes;
+use winnow::Parser;
 
 use crate::v5::MResult;
 

--- a/mqtt-format/src/v5/packets/puback.rs
+++ b/mqtt-format/src/v5/packets/puback.rs
@@ -6,11 +6,11 @@
 
 use winnow::Bytes;
 
-use crate::v5::{
-    properties::define_properties,
-    variable_header::{PacketIdentifier, ReasonString, UserProperties},
-    MResult,
-};
+use crate::v5::properties::define_properties;
+use crate::v5::variable_header::PacketIdentifier;
+use crate::v5::variable_header::ReasonString;
+use crate::v5::variable_header::UserProperties;
+use crate::v5::MResult;
 
 crate::v5::reason_code::make_combined_reason_code! {
     pub enum PubackReasonCode {

--- a/mqtt-format/src/v5/packets/pubcomp.rs
+++ b/mqtt-format/src/v5/packets/pubcomp.rs
@@ -6,10 +6,10 @@
 
 use winnow::Bytes;
 
-use crate::v5::{
-    variable_header::{PacketIdentifier, ReasonString, UserProperties},
-    MResult,
-};
+use crate::v5::variable_header::PacketIdentifier;
+use crate::v5::variable_header::ReasonString;
+use crate::v5::variable_header::UserProperties;
+use crate::v5::MResult;
 
 crate::v5::reason_code::make_combined_reason_code! {
     pub enum PubcompReasonCode {

--- a/mqtt-format/src/v5/packets/publish.rs
+++ b/mqtt-format/src/v5/packets/publish.rs
@@ -4,20 +4,21 @@
 //   file, You can obtain one at http://mozilla.org/MPL/2.0/.
 //
 
-use winnow::{
-    error::{ErrMode, ParserError},
-    stream::Stream,
-    Bytes,
-};
+use winnow::error::ErrMode;
+use winnow::error::ParserError;
+use winnow::stream::Stream;
+use winnow::Bytes;
 
-use crate::v5::{
-    fixed_header::QualityOfService,
-    variable_header::{
-        ContentType, CorrelationData, MessageExpiryInterval, PayloadFormatIndicator, ResponseTopic,
-        SubscriptionIdentifier, TopicAlias, UserProperties,
-    },
-    MResult,
-};
+use crate::v5::fixed_header::QualityOfService;
+use crate::v5::variable_header::ContentType;
+use crate::v5::variable_header::CorrelationData;
+use crate::v5::variable_header::MessageExpiryInterval;
+use crate::v5::variable_header::PayloadFormatIndicator;
+use crate::v5::variable_header::ResponseTopic;
+use crate::v5::variable_header::SubscriptionIdentifier;
+use crate::v5::variable_header::TopicAlias;
+use crate::v5::variable_header::UserProperties;
+use crate::v5::MResult;
 
 #[derive(Debug)]
 #[doc = crate::v5::util::md_speclink!("_Toc3901100")]

--- a/mqtt-format/src/v5/packets/pubrec.rs
+++ b/mqtt-format/src/v5/packets/pubrec.rs
@@ -6,10 +6,10 @@
 
 use winnow::Bytes;
 
-use crate::v5::{
-    variable_header::{PacketIdentifier, ReasonString, UserProperties},
-    MResult,
-};
+use crate::v5::variable_header::PacketIdentifier;
+use crate::v5::variable_header::ReasonString;
+use crate::v5::variable_header::UserProperties;
+use crate::v5::MResult;
 
 crate::v5::reason_code::make_combined_reason_code! {
     pub enum PubrecReasonCode {

--- a/mqtt-format/src/v5/packets/pubrel.rs
+++ b/mqtt-format/src/v5/packets/pubrel.rs
@@ -6,11 +6,11 @@
 
 use winnow::Bytes;
 
-use crate::v5::{
-    properties::define_properties,
-    variable_header::{PacketIdentifier, ReasonString, UserProperties},
-    MResult,
-};
+use crate::v5::properties::define_properties;
+use crate::v5::variable_header::PacketIdentifier;
+use crate::v5::variable_header::ReasonString;
+use crate::v5::variable_header::UserProperties;
+use crate::v5::MResult;
 
 crate::v5::reason_code::make_combined_reason_code! {
     pub enum PubrelReasonCode {

--- a/mqtt-format/src/v5/packets/suback.rs
+++ b/mqtt-format/src/v5/packets/suback.rs
@@ -4,12 +4,13 @@
 //   file, You can obtain one at http://mozilla.org/MPL/2.0/.
 //
 
-use winnow::{Bytes, Parser};
+use winnow::Bytes;
+use winnow::Parser;
 
-use crate::v5::{
-    variable_header::{PacketIdentifier, ReasonString, UserProperties},
-    MResult,
-};
+use crate::v5::variable_header::PacketIdentifier;
+use crate::v5::variable_header::ReasonString;
+use crate::v5::variable_header::UserProperties;
+use crate::v5::MResult;
 
 crate::v5::reason_code::make_combined_reason_code! {
     pub enum SubackReasonCode {

--- a/mqtt-format/src/v5/packets/subscribe.rs
+++ b/mqtt-format/src/v5/packets/subscribe.rs
@@ -4,20 +4,21 @@
 //   file, You can obtain one at http://mozilla.org/MPL/2.0/.
 //
 
-use winnow::{
-    binary::bits::bits,
-    combinator::repeat_till,
-    error::{ErrMode, InputError, ParserError},
-    Bytes, Parser,
-};
+use winnow::binary::bits::bits;
+use winnow::combinator::repeat_till;
+use winnow::error::ErrMode;
+use winnow::error::InputError;
+use winnow::error::ParserError;
+use winnow::Bytes;
+use winnow::Parser;
 
-use crate::v5::{
-    fixed_header::QualityOfService,
-    properties::define_properties,
-    strings::parse_string,
-    variable_header::{PacketIdentifier, SubscriptionIdentifier, UserProperties},
-    MResult,
-};
+use crate::v5::fixed_header::QualityOfService;
+use crate::v5::properties::define_properties;
+use crate::v5::strings::parse_string;
+use crate::v5::variable_header::PacketIdentifier;
+use crate::v5::variable_header::SubscriptionIdentifier;
+use crate::v5::variable_header::UserProperties;
+use crate::v5::MResult;
 
 define_properties! {
     pub struct SubscribeProperties<'i> {

--- a/mqtt-format/src/v5/packets/unsuback.rs
+++ b/mqtt-format/src/v5/packets/unsuback.rs
@@ -7,10 +7,10 @@
 use winnow::Bytes;
 use winnow::Parser;
 
-use crate::v5::{
-    variable_header::{PacketIdentifier, ReasonString, UserProperties},
-    MResult,
-};
+use crate::v5::variable_header::PacketIdentifier;
+use crate::v5::variable_header::ReasonString;
+use crate::v5::variable_header::UserProperties;
+use crate::v5::MResult;
 
 crate::v5::reason_code::make_combined_reason_code! {
     pub enum UnsubackReasonCode {

--- a/mqtt-format/src/v5/packets/unsubscribe.rs
+++ b/mqtt-format/src/v5/packets/unsubscribe.rs
@@ -4,14 +4,16 @@
 //   file, You can obtain one at http://mozilla.org/MPL/2.0/.
 //
 
-use winnow::{combinator::repeat_till, Bytes, Parser};
+use winnow::combinator::repeat_till;
+use winnow::Bytes;
+use winnow::Parser;
 
-use crate::v5::{
-    properties::define_properties,
-    strings::parse_string,
-    variable_header::{PacketIdentifier, SubscriptionIdentifier, UserProperties},
-    MResult,
-};
+use crate::v5::properties::define_properties;
+use crate::v5::strings::parse_string;
+use crate::v5::variable_header::PacketIdentifier;
+use crate::v5::variable_header::SubscriptionIdentifier;
+use crate::v5::variable_header::UserProperties;
+use crate::v5::MResult;
 
 define_properties! {
     packet_type: MUnsubscribe,

--- a/mqtt-format/src/v5/properties.rs
+++ b/mqtt-format/src/v5/properties.rs
@@ -4,10 +4,9 @@
 //   file, You can obtain one at http://mozilla.org/MPL/2.0/.
 //
 
-use winnow::{
-    error::{ErrMode, ParserError},
-    Bytes,
-};
+use winnow::error::ErrMode;
+use winnow::error::ParserError;
+use winnow::Bytes;
 
 use super::MResult;
 

--- a/mqtt-format/src/v5/strings.rs
+++ b/mqtt-format/src/v5/strings.rs
@@ -4,13 +4,14 @@
 //   file, You can obtain one at http://mozilla.org/MPL/2.0/.
 //
 
-use winnow::{
-    binary::length_take,
-    error::{ErrMode, FromExternalError},
-    Bytes, Parser,
-};
+use winnow::binary::length_take;
+use winnow::error::ErrMode;
+use winnow::error::FromExternalError;
+use winnow::Bytes;
+use winnow::Parser;
 
-use super::{integers::parse_u16, MResult};
+use super::integers::parse_u16;
+use super::MResult;
 
 pub fn parse_string<'i>(input: &mut &'i Bytes) -> MResult<&'i str> {
     let maybe_str = length_take(parse_u16).parse_next(input)?;

--- a/mqtt-format/src/v5/variable_header.rs
+++ b/mqtt-format/src/v5/variable_header.rs
@@ -4,9 +4,12 @@
 //   file, You can obtain one at http://mozilla.org/MPL/2.0/.
 //
 
-use winnow::{Bytes, Parser};
+use winnow::Bytes;
+use winnow::Parser;
 
-use super::{integers::parse_u16, integers::parse_u32, MResult};
+use super::integers::parse_u16;
+use super::integers::parse_u32;
+use super::MResult;
 
 #[derive(Debug, Clone, Copy)]
 pub struct PacketIdentifier(pub u16);
@@ -210,9 +213,10 @@ impl<'i> Iterator for UserPropertyIterator<'i> {
 
 #[cfg(test)]
 mod tests {
-    use crate::v5::variable_header::{MqttProperties, RetainAvailable, UserProperty};
-
     use super::UserProperties;
+    use crate::v5::variable_header::MqttProperties;
+    use crate::v5::variable_header::RetainAvailable;
+    use crate::v5::variable_header::UserProperty;
 
     #[test]
     fn check_iteration() {

--- a/mqtt-tester/src/behaviour/connack_flags_are_set_as_reserved.rs
+++ b/mqtt-tester/src/behaviour/connack_flags_are_set_as_reserved.rs
@@ -6,12 +6,11 @@
 
 use miette::Context;
 
-use crate::{
-    behaviour_test::BehaviourTest,
-    command::{Input, Output},
-    executable::ClientExecutableCommand,
-    report::ReportResult,
-};
+use crate::behaviour_test::BehaviourTest;
+use crate::command::Input;
+use crate::command::Output;
+use crate::executable::ClientExecutableCommand;
+use crate::report::ReportResult;
 
 pub struct ConnackFlagsAreSetAsReserved;
 

--- a/mqtt-tester/src/behaviour/first_packet_from_client_is_connect.rs
+++ b/mqtt-tester/src/behaviour/first_packet_from_client_is_connect.rs
@@ -7,12 +7,11 @@
 use miette::Context;
 use mqtt_format::v3::packet::MPacket;
 
-use crate::{
-    behaviour_test::BehaviourTest,
-    command::{Input, Output},
-    executable::ClientExecutableCommand,
-    report::ReportResult,
-};
+use crate::behaviour_test::BehaviourTest;
+use crate::command::Input;
+use crate::command::Output;
+use crate::executable::ClientExecutableCommand;
+use crate::report::ReportResult;
 
 pub struct FirstPacketFromClientIsConnect;
 

--- a/mqtt-tester/src/behaviour/invalid_first_packet_is_rejected.rs
+++ b/mqtt-tester/src/behaviour/invalid_first_packet_is_rejected.rs
@@ -5,14 +5,14 @@
 //
 
 use miette::Context;
-use mqtt_format::v3::{packet::MConnect, strings::MString};
+use mqtt_format::v3::packet::MConnect;
+use mqtt_format::v3::strings::MString;
 
-use crate::{
-    behaviour_test::BehaviourTest,
-    command::{Input, Output},
-    executable::ClientExecutableCommand,
-    report::ReportResult,
-};
+use crate::behaviour_test::BehaviourTest;
+use crate::command::Input;
+use crate::command::Output;
+use crate::executable::ClientExecutableCommand;
+use crate::report::ReportResult;
 
 pub struct InvalidFirstPacketIsRejected;
 

--- a/mqtt-tester/src/behaviour/invalid_utf8_is_rejected.rs
+++ b/mqtt-tester/src/behaviour/invalid_utf8_is_rejected.rs
@@ -5,14 +5,14 @@
 //
 
 use miette::Context;
-use mqtt_format::v3::{connect_return::MConnectReturnCode, packet::MConnack};
+use mqtt_format::v3::connect_return::MConnectReturnCode;
+use mqtt_format::v3::packet::MConnack;
 
-use crate::{
-    behaviour_test::BehaviourTest,
-    command::{Input, Output},
-    executable::ClientExecutableCommand,
-    report::ReportResult,
-};
+use crate::behaviour_test::BehaviourTest;
+use crate::command::Input;
+use crate::command::Output;
+use crate::executable::ClientExecutableCommand;
+use crate::report::ReportResult;
 
 pub struct InvalidUtf8IsRejected;
 

--- a/mqtt-tester/src/behaviour/publish_qos_2_is_acked.rs
+++ b/mqtt-tester/src/behaviour/publish_qos_2_is_acked.rs
@@ -5,20 +5,18 @@
 //
 
 use miette::Context;
-use mqtt_format::v3::{
-    connect_return::MConnectReturnCode,
-    identifier::MPacketIdentifier,
-    packet::{MConnack, MPublish},
-    qos::MQualityOfService,
-    strings::MString,
-};
+use mqtt_format::v3::connect_return::MConnectReturnCode;
+use mqtt_format::v3::identifier::MPacketIdentifier;
+use mqtt_format::v3::packet::MConnack;
+use mqtt_format::v3::packet::MPublish;
+use mqtt_format::v3::qos::MQualityOfService;
+use mqtt_format::v3::strings::MString;
 
-use crate::{
-    behaviour_test::BehaviourTest,
-    command::{Input, Output},
-    executable::ClientExecutableCommand,
-    report::ReportResult,
-};
+use crate::behaviour_test::BehaviourTest;
+use crate::command::Input;
+use crate::command::Output;
+use crate::executable::ClientExecutableCommand;
+use crate::report::ReportResult;
 
 pub struct PublishQos2IsAcked;
 

--- a/mqtt-tester/src/behaviour/publish_qos_zero_with_ident_fails.rs
+++ b/mqtt-tester/src/behaviour/publish_qos_zero_with_ident_fails.rs
@@ -5,20 +5,18 @@
 //
 
 use miette::Context;
-use mqtt_format::v3::{
-    connect_return::MConnectReturnCode,
-    identifier::MPacketIdentifier,
-    packet::{MConnack, MPublish},
-    qos::MQualityOfService,
-    strings::MString,
-};
+use mqtt_format::v3::connect_return::MConnectReturnCode;
+use mqtt_format::v3::identifier::MPacketIdentifier;
+use mqtt_format::v3::packet::MConnack;
+use mqtt_format::v3::packet::MPublish;
+use mqtt_format::v3::qos::MQualityOfService;
+use mqtt_format::v3::strings::MString;
 
-use crate::{
-    behaviour_test::BehaviourTest,
-    command::{Input, Output},
-    executable::ClientExecutableCommand,
-    report::ReportResult,
-};
+use crate::behaviour_test::BehaviourTest;
+use crate::command::Input;
+use crate::command::Output;
+use crate::executable::ClientExecutableCommand;
+use crate::report::ReportResult;
 
 pub struct PublishQosZeroWithIdentFails;
 

--- a/mqtt-tester/src/behaviour/receiving_server_packet.rs
+++ b/mqtt-tester/src/behaviour/receiving_server_packet.rs
@@ -5,19 +5,17 @@
 //
 
 use miette::Context;
-use mqtt_format::v3::{
-    connect_return::MConnectReturnCode,
-    identifier::MPacketIdentifier,
-    packet::{MConnack, MSubscribe},
-    subscription_request::MSubscriptionRequests,
-};
+use mqtt_format::v3::connect_return::MConnectReturnCode;
+use mqtt_format::v3::identifier::MPacketIdentifier;
+use mqtt_format::v3::packet::MConnack;
+use mqtt_format::v3::packet::MSubscribe;
+use mqtt_format::v3::subscription_request::MSubscriptionRequests;
 
-use crate::{
-    behaviour_test::BehaviourTest,
-    command::{Input, Output},
-    executable::ClientExecutableCommand,
-    report::ReportResult,
-};
+use crate::behaviour_test::BehaviourTest;
+use crate::command::Input;
+use crate::command::Output;
+use crate::executable::ClientExecutableCommand;
+use crate::report::ReportResult;
 
 pub struct ReceivingServerPacket;
 

--- a/mqtt-tester/src/behaviour/utf8_with_nullchar_is_rejected.rs
+++ b/mqtt-tester/src/behaviour/utf8_with_nullchar_is_rejected.rs
@@ -5,17 +5,16 @@
 //
 
 use miette::Context;
-use mqtt_format::v3::{
-    connect_return::MConnectReturnCode, header::MPacketKind, packet::MConnack,
-    qos::MQualityOfService,
-};
+use mqtt_format::v3::connect_return::MConnectReturnCode;
+use mqtt_format::v3::header::MPacketKind;
+use mqtt_format::v3::packet::MConnack;
+use mqtt_format::v3::qos::MQualityOfService;
 
-use crate::{
-    behaviour_test::BehaviourTest,
-    command::{Input, Output},
-    executable::ClientExecutableCommand,
-    report::ReportResult,
-};
+use crate::behaviour_test::BehaviourTest;
+use crate::command::Input;
+use crate::command::Output;
+use crate::executable::ClientExecutableCommand;
+use crate::report::ReportResult;
 
 pub struct Utf8WithNullcharIsRejected;
 

--- a/mqtt-tester/src/behaviour/wait_for_connect.rs
+++ b/mqtt-tester/src/behaviour/wait_for_connect.rs
@@ -5,14 +5,14 @@
 //
 
 use miette::Context;
-use mqtt_format::v3::{connect_return::MConnectReturnCode, packet::MConnack};
+use mqtt_format::v3::connect_return::MConnectReturnCode;
+use mqtt_format::v3::packet::MConnack;
 
-use crate::{
-    behaviour_test::BehaviourTest,
-    command::{Input, Output},
-    executable::ClientExecutableCommand,
-    report::ReportResult,
-};
+use crate::behaviour_test::BehaviourTest;
+use crate::command::Input;
+use crate::command::Output;
+use crate::executable::ClientExecutableCommand;
+use crate::report::ReportResult;
 
 pub struct WaitForConnect;
 

--- a/mqtt-tester/src/behaviour_test.rs
+++ b/mqtt-tester/src/behaviour_test.rs
@@ -4,11 +4,10 @@
 //   file, You can obtain one at http://mozilla.org/MPL/2.0/.
 //
 
-use crate::{
-    command::{Input, Output},
-    executable::ClientExecutableCommand,
-    report::ReportResult,
-};
+use crate::command::Input;
+use crate::command::Output;
+use crate::executable::ClientExecutableCommand;
+use crate::report::ReportResult;
 
 #[async_trait::async_trait]
 pub trait BehaviourTest {

--- a/mqtt-tester/src/client_report.rs
+++ b/mqtt-tester/src/client_report.rs
@@ -8,16 +8,17 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use futures::FutureExt;
-
 use miette::Context;
-use mqtt_format::v3::packet::{MConnect, MPacket};
+use mqtt_format::v3::packet::MConnect;
+use mqtt_format::v3::packet::MPacket;
 
 use crate::behaviour_test::BehaviourTest;
 use crate::executable::ClientExecutable;
 use crate::invariant::connect_packet_protocol_name::ConnectPacketProtocolName;
 use crate::invariant::no_username_means_no_password::NoUsernameMeansNoPassword;
 use crate::packet_invariant::PacketInvariant;
-use crate::report::{Report, ReportResult};
+use crate::report::Report;
+use crate::report::ReportResult;
 
 pub async fn create_client_report(
     client_exe_path: PathBuf,

--- a/mqtt-tester/src/command.rs
+++ b/mqtt-tester/src/command.rs
@@ -6,16 +6,18 @@
 
 use std::sync::Arc;
 
-use bytes::{BufMut, BytesMut};
+use bytes::BufMut;
+use bytes::BytesMut;
 use miette::IntoDiagnostic;
 use mqtt_format::v3::packet::MPacket;
-use tokio::{
-    io::{AsyncReadExt, AsyncWriteExt},
-    process::{ChildStdin, ChildStdout},
-};
+use tokio::io::AsyncReadExt;
+use tokio::io::AsyncWriteExt;
+use tokio::process::ChildStdin;
+use tokio::process::ChildStdout;
 use tracing::Instrument;
 
-use crate::{packet_invariant::PacketInvariant, report::ReportResult};
+use crate::packet_invariant::PacketInvariant;
+use crate::report::ReportResult;
 
 pub struct Command {
     inner: tokio::process::Command,

--- a/mqtt-tester/src/invariant/connect_packet_protocol_name.rs
+++ b/mqtt-tester/src/invariant/connect_packet_protocol_name.rs
@@ -4,15 +4,13 @@
 //   file, You can obtain one at http://mozilla.org/MPL/2.0/.
 //
 
-use mqtt_format::v3::{
-    packet::{MConnect, MPacket},
-    strings::MString,
-};
+use mqtt_format::v3::packet::MConnect;
+use mqtt_format::v3::packet::MPacket;
+use mqtt_format::v3::strings::MString;
 
-use crate::{
-    packet_invariant::PacketInvariant,
-    report::{Report, ReportResult},
-};
+use crate::packet_invariant::PacketInvariant;
+use crate::report::Report;
+use crate::report::ReportResult;
 
 pub struct ConnectPacketProtocolName;
 

--- a/mqtt-tester/src/invariant/no_username_means_no_password.rs
+++ b/mqtt-tester/src/invariant/no_username_means_no_password.rs
@@ -4,12 +4,12 @@
 //   file, You can obtain one at http://mozilla.org/MPL/2.0/.
 //
 
-use mqtt_format::v3::packet::{MConnect, MPacket};
+use mqtt_format::v3::packet::MConnect;
+use mqtt_format::v3::packet::MPacket;
 
-use crate::{
-    packet_invariant::PacketInvariant,
-    report::{Report, ReportResult},
-};
+use crate::packet_invariant::PacketInvariant;
+use crate::report::Report;
+use crate::report::ReportResult;
 
 pub struct NoUsernameMeansNoPassword;
 

--- a/mqtt-tester/src/main.rs
+++ b/mqtt-tester/src/main.rs
@@ -13,13 +13,17 @@ mod invariant;
 mod packet_invariant;
 mod report;
 
-use std::{path::PathBuf, process::exit};
+use std::path::PathBuf;
+use std::process::exit;
 
-use clap::{Parser, Subcommand};
+use clap::Parser;
+use clap::Subcommand;
 use client_report::create_client_report;
 use miette::IntoDiagnostic;
-use report::{print_report, ReportResult};
-use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
+use report::print_report;
+use report::ReportResult;
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::util::SubscriberInitExt;
 
 #[derive(Parser, Debug)]
 #[clap(author, version)]

--- a/mqtt-tester/src/report.rs
+++ b/mqtt-tester/src/report.rs
@@ -51,7 +51,10 @@ impl std::fmt::Debug for Report {
 }
 
 pub fn print_report(report: &Report, mut writer: impl Write) -> Result<(), std::io::Error> {
-    use ansi_term::Colour::{Blue, Green, Red, Yellow};
+    use ansi_term::Colour::Blue;
+    use ansi_term::Colour::Green;
+    use ansi_term::Colour::Red;
+    use ansi_term::Colour::Yellow;
     write!(writer, "{} ... ", Blue.paint(&report.name))?;
 
     match report.result {

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,3 @@
+imports_granularity = "Item"
+reorder_imports = true
+group_imports = "StdExternalCrate"

--- a/src/bin/cloudmqtt-client.rs
+++ b/src/bin/cloudmqtt-client.rs
@@ -5,14 +5,13 @@
 //
 
 use clap::Parser;
-use cloudmqtt::{
-    client::{MqttClient, MqttConnectionParams},
-    packet_stream::Acknowledge,
-};
+use cloudmqtt::client::MqttClient;
+use cloudmqtt::client::MqttConnectionParams;
+use cloudmqtt::packet_stream::Acknowledge;
 use futures::StreamExt;
-use mqtt_format::v3::{
-    strings::MString, subscription_request::MSubscriptionRequest, will::MLastWill,
-};
+use mqtt_format::v3::strings::MString;
+use mqtt_format::v3::subscription_request::MSubscriptionRequest;
+use mqtt_format::v3::will::MLastWill;
 use tracing::error;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;

--- a/src/bin/cloudmqtt-server.rs
+++ b/src/bin/cloudmqtt-server.rs
@@ -6,8 +6,11 @@
 
 use std::sync::Arc;
 
-use cloudmqtt::server::handler::{LoginError, LoginHandler, SubscriptionHandler};
-use cloudmqtt::server::{ClientId, MqttServer};
+use cloudmqtt::server::handler::LoginError;
+use cloudmqtt::server::handler::LoginHandler;
+use cloudmqtt::server::handler::SubscriptionHandler;
+use cloudmqtt::server::ClientId;
+use cloudmqtt::server::MqttServer;
 use mqtt_format::v3::qos::MQualityOfService;
 use mqtt_format::v3::subscription_request::MSubscriptionRequest;
 use tracing::info;

--- a/src/bin/cloudmqtt-test-client.rs
+++ b/src/bin/cloudmqtt-test-client.rs
@@ -7,15 +7,15 @@
 use std::process::exit;
 
 use clap::Parser;
-use cloudmqtt::{client::MqttClient, client::MqttConnectionParams};
+use cloudmqtt::client::MqttClient;
+use cloudmqtt::client::MqttConnectionParams;
 use futures::StreamExt;
-use mqtt_format::v3::{
-    packet::{MPacket, MPublish},
-    qos::MQualityOfService,
-    strings::MString,
-    subscription_request::MSubscriptionRequest,
-    will::MLastWill,
-};
+use mqtt_format::v3::packet::MPacket;
+use mqtt_format::v3::packet::MPublish;
+use mqtt_format::v3::qos::MQualityOfService;
+use mqtt_format::v3::strings::MString;
+use mqtt_format::v3::subscription_request::MSubscriptionRequest;
+use mqtt_format::v3::will::MLastWill;
 
 fn print_error_and_quit(e: String) -> ! {
     eprintln!("{}", e);

--- a/src/client.rs
+++ b/src/client.rs
@@ -4,30 +4,40 @@
 //   file, You can obtain one at http://mozilla.org/MPL/2.0/.
 //
 
-use std::{pin::Pin, sync::Arc, time::Duration};
+use std::pin::Pin;
+use std::sync::Arc;
+use std::time::Duration;
 
 use dashmap::DashSet;
-use mqtt_format::v3::{
-    identifier::MPacketIdentifier,
-    packet::{
-        MConnack, MConnect, MPacket, MPingreq, MPuback, MPubcomp, MPublish, MPubrec, MPubrel,
-        MSubscribe,
-    },
-    qos::MQualityOfService,
-    strings::MString,
-    subscription_request::{MSubscriptionRequest, MSubscriptionRequests},
-    will::MLastWill,
-};
-use tokio::{
-    io::{DuplexStream, ReadHalf, WriteHalf},
-    net::{TcpStream, ToSocketAddrs},
-    sync::Mutex,
-};
+use mqtt_format::v3::identifier::MPacketIdentifier;
+use mqtt_format::v3::packet::MConnack;
+use mqtt_format::v3::packet::MConnect;
+use mqtt_format::v3::packet::MPacket;
+use mqtt_format::v3::packet::MPingreq;
+use mqtt_format::v3::packet::MPuback;
+use mqtt_format::v3::packet::MPubcomp;
+use mqtt_format::v3::packet::MPublish;
+use mqtt_format::v3::packet::MPubrec;
+use mqtt_format::v3::packet::MPubrel;
+use mqtt_format::v3::packet::MSubscribe;
+use mqtt_format::v3::qos::MQualityOfService;
+use mqtt_format::v3::strings::MString;
+use mqtt_format::v3::subscription_request::MSubscriptionRequest;
+use mqtt_format::v3::subscription_request::MSubscriptionRequests;
+use mqtt_format::v3::will::MLastWill;
+use tokio::io::DuplexStream;
+use tokio::io::ReadHalf;
+use tokio::io::WriteHalf;
+use tokio::net::TcpStream;
+use tokio::net::ToSocketAddrs;
+use tokio::sync::Mutex;
 use tokio_util::sync::CancellationToken;
 use tracing::trace;
 
-use crate::packet_stream::{NoOPAck, PacketStreamBuilder};
-use crate::{error::MqttError, mqtt_stream::MqttStream};
+use crate::error::MqttError;
+use crate::mqtt_stream::MqttStream;
+use crate::packet_stream::NoOPAck;
+use crate::packet_stream::PacketStreamBuilder;
 
 pub struct MqttClient {
     session_present: bool,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,15 +8,18 @@
 use std::pin::Pin;
 use std::sync::Arc;
 
-use bytes::{BufMut, BytesMut};
+use bytes::BufMut;
+use bytes::BytesMut;
 use futures::io::BufWriter;
 use futures::AsyncWriteExt;
 use mqtt_format::v3::errors::MPacketWriteError;
-use mqtt_format::v3::{header::mfixedheader, packet::MPacket};
+use mqtt_format::v3::header::mfixedheader;
+use mqtt_format::v3::packet::MPacket;
 use tokio::io::AsyncReadExt;
 use tokio::io::AsyncWrite;
 use tokio_util::compat::TokioAsyncWriteCompatExt;
-use tracing::{debug, trace};
+use tracing::debug;
+use tracing::trace;
 use yoke::Yoke;
 
 pub mod client;
@@ -26,7 +29,8 @@ pub mod mqtt_stream;
 pub mod packet_stream;
 pub mod server;
 
-pub use mqtt_packet::{MqttPacket, MqttSubPacket};
+pub use mqtt_packet::MqttPacket;
+pub use mqtt_packet::MqttSubPacket;
 
 fn parse_packet(input: &[u8]) -> Result<MPacket<'_>, PacketIOError> {
     match nom::combinator::all_consuming(mqtt_format::v3::packet::mpacket)(input) {

--- a/src/mqtt_packet.rs
+++ b/src/mqtt_packet.rs
@@ -7,7 +7,8 @@ use std::sync::Arc;
 
 use bytes::Bytes;
 use mqtt_format::v3::packet::MPacket;
-use yoke::{Yoke, Yokeable};
+use yoke::Yoke;
+use yoke::Yokeable;
 
 #[derive(Clone)]
 pub struct MqttPacket {

--- a/src/mqtt_stream.rs
+++ b/src/mqtt_stream.rs
@@ -4,7 +4,8 @@
 //   file, You can obtain one at http://mozilla.org/MPL/2.0/.
 //
 
-use tokio::io::{AsyncRead, AsyncWrite};
+use tokio::io::AsyncRead;
+use tokio::io::AsyncWrite;
 
 #[derive(Debug)]
 pub enum MqttStream {

--- a/src/packet_stream.rs
+++ b/src/packet_stream.rs
@@ -6,13 +6,18 @@
 
 use std::future::Ready;
 
-use crate::{client::MqttClient, error::MqttError, MqttPacket};
 use futures::Stream;
-use mqtt_format::v3::{
-    packet::{MPacket, MPublish, MPubrel},
-    qos::MQualityOfService,
-};
-use tracing::{debug, error, trace};
+use mqtt_format::v3::packet::MPacket;
+use mqtt_format::v3::packet::MPublish;
+use mqtt_format::v3::packet::MPubrel;
+use mqtt_format::v3::qos::MQualityOfService;
+use tracing::debug;
+use tracing::error;
+use tracing::trace;
+
+use crate::client::MqttClient;
+use crate::error::MqttError;
+use crate::MqttPacket;
 
 pub struct Acknowledge;
 
@@ -195,7 +200,9 @@ impl<'client, ACK: AckHandler> PacketStream<'client, ACK> {
 mod tests {
     use futures::StreamExt;
 
-    use crate::{client::MqttClient, packet_stream::Acknowledge, MqttPacket};
+    use crate::client::MqttClient;
+    use crate::packet_stream::Acknowledge;
+    use crate::MqttPacket;
 
     #[allow(unreachable_code, unused, clippy::diverging_sub_expression)]
     async fn check_making_stream_builder() {

--- a/src/server/handler.rs
+++ b/src/server/handler.rs
@@ -5,10 +5,9 @@
 //
 use std::sync::Arc;
 
-use mqtt_format::v3::{
-    connect_return::MConnectReturnCode, qos::MQualityOfService,
-    subscription_request::MSubscriptionRequest,
-};
+use mqtt_format::v3::connect_return::MConnectReturnCode;
+use mqtt_format::v3::qos::MQualityOfService;
+use mqtt_format::v3::subscription_request::MSubscriptionRequest;
 
 use crate::server::ClientId;
 

--- a/src/server/message.rs
+++ b/src/server/message.rs
@@ -5,7 +5,8 @@
 //
 use std::sync::Arc;
 
-use mqtt_format::v3::{qos::MQualityOfService, will::MLastWill};
+use mqtt_format::v3::qos::MQualityOfService;
+use mqtt_format::v3::will::MLastWill;
 
 use super::ClientId;
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -35,39 +35,55 @@ mod message;
 mod state;
 mod subscriptions;
 
-use std::{sync::Arc, time::Duration};
+use std::sync::Arc;
+use std::time::Duration;
 
 use dashmap::DashMap;
-use mqtt_format::v3::{
-    connect_return::MConnectReturnCode,
-    packet::{
-        MConnack, MConnect, MDisconnect, MPacket, MPingreq, MPingresp, MPuback, MPubcomp, MPublish,
-        MPubrec, MPubrel, MSuback, MSubscribe,
-    },
-    qos::MQualityOfService,
-    strings::MString,
-    subscription_acks::MSubscriptionAcks,
-    will::MLastWill,
-};
-use tokio::{
-    io::{AsyncWriteExt, DuplexStream, ReadHalf, WriteHalf},
-    net::{TcpListener, ToSocketAddrs},
-    sync::broadcast::Sender as BroadcastSender,
-    sync::Mutex,
-};
-use tracing::{debug, error, info, trace, warn};
+use mqtt_format::v3::connect_return::MConnectReturnCode;
+use mqtt_format::v3::packet::MConnack;
+use mqtt_format::v3::packet::MConnect;
+use mqtt_format::v3::packet::MDisconnect;
+use mqtt_format::v3::packet::MPacket;
+use mqtt_format::v3::packet::MPingreq;
+use mqtt_format::v3::packet::MPingresp;
+use mqtt_format::v3::packet::MPuback;
+use mqtt_format::v3::packet::MPubcomp;
+use mqtt_format::v3::packet::MPublish;
+use mqtt_format::v3::packet::MPubrec;
+use mqtt_format::v3::packet::MPubrel;
+use mqtt_format::v3::packet::MSuback;
+use mqtt_format::v3::packet::MSubscribe;
+use mqtt_format::v3::qos::MQualityOfService;
+use mqtt_format::v3::strings::MString;
+use mqtt_format::v3::subscription_acks::MSubscriptionAcks;
+use mqtt_format::v3::will::MLastWill;
+use subscriptions::ClientInformation;
+use subscriptions::SubscriptionManager;
+use tokio::io::AsyncWriteExt;
+use tokio::io::DuplexStream;
+use tokio::io::ReadHalf;
+use tokio::io::WriteHalf;
+use tokio::net::TcpListener;
+use tokio::net::ToSocketAddrs;
+use tokio::sync::broadcast::Sender as BroadcastSender;
+use tokio::sync::Mutex;
+use tracing::debug;
+use tracing::error;
+use tracing::info;
+use tracing::trace;
+use tracing::warn;
 
-use crate::{error::MqttError, mqtt_stream::MqttStream, PacketIOError};
-use subscriptions::{ClientInformation, SubscriptionManager};
-
-use self::{
-    handler::{
-        AllowAllLogins, AllowAllSubscriptions, LoginError, LoginHandler, SubscriptionHandler,
-    },
-    message::MqttMessage,
-    state::ClientState,
-    subscriptions::TopicFilter,
-};
+use self::handler::AllowAllLogins;
+use self::handler::AllowAllSubscriptions;
+use self::handler::LoginError;
+use self::handler::LoginHandler;
+use self::handler::SubscriptionHandler;
+use self::message::MqttMessage;
+use self::state::ClientState;
+use self::subscriptions::TopicFilter;
+use crate::error::MqttError;
+use crate::mqtt_stream::MqttStream;
+use crate::PacketIOError;
 
 /// The unique id (per server) of a connecting client
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -29,21 +29,26 @@
 //! new connection, starting from the `current_id` field.
 //!
 
-use std::{
-    collections::VecDeque,
-    sync::{atomic::AtomicU16, Arc},
-};
+use std::collections::VecDeque;
+use std::sync::atomic::AtomicU16;
+use std::sync::Arc;
 
-use arc_swap::{ArcSwap, ArcSwapOption};
-use dashmap::{mapref::entry::Entry, DashMap, DashSet};
-use mqtt_format::v3::{identifier::MPacketIdentifier, packet::MPublish, qos::MQualityOfService};
+use arc_swap::ArcSwap;
+use arc_swap::ArcSwapOption;
+use dashmap::mapref::entry::Entry;
+use dashmap::DashMap;
+use dashmap::DashSet;
+use mqtt_format::v3::identifier::MPacketIdentifier;
+use mqtt_format::v3::packet::MPublish;
+use mqtt_format::v3::qos::MQualityOfService;
 use tokio::io::AsyncWriteExt;
 use tokio_util::sync::CancellationToken;
-use tracing::{debug, trace};
+use tracing::debug;
+use tracing::trace;
 
+use super::message::MqttMessage;
+use super::ClientConnection;
 use crate::error::MqttError;
-
-use super::{message::MqttMessage, ClientConnection};
 
 /// A Message that is unacknowledged, at what state depends on the current `packet`
 ///

--- a/src/server/subscriptions.rs
+++ b/src/server/subscriptions.rs
@@ -4,22 +4,23 @@
 //   file, You can obtain one at http://mozilla.org/MPL/2.0/.
 //
 
-use std::{
-    collections::{HashMap, VecDeque},
-    sync::Arc,
-};
+use std::collections::HashMap;
+use std::collections::VecDeque;
+use std::sync::Arc;
 
 use arc_swap::ArcSwap;
-use futures::{stream::FuturesUnordered, StreamExt};
-use mqtt_format::v3::{
-    qos::MQualityOfService, subscription_acks::MSubscriptionAck,
-    subscription_request::MSubscriptionRequests,
-};
-use tracing::{debug, trace};
+use futures::stream::FuturesUnordered;
+use futures::StreamExt;
+use mqtt_format::v3::qos::MQualityOfService;
+use mqtt_format::v3::subscription_acks::MSubscriptionAck;
+use mqtt_format::v3::subscription_request::MSubscriptionRequests;
+use tracing::debug;
+use tracing::trace;
 
-use crate::server::{ClientId, MqttMessage};
-
-use super::handler::{AllowAllSubscriptions, SubscriptionHandler};
+use super::handler::AllowAllSubscriptions;
+use super::handler::SubscriptionHandler;
+use crate::server::ClientId;
+use crate::server::MqttMessage;
 
 // foo/barr/# => vec![Named, Named, MultiWildcard]
 // /foo/barr/# => vec![Empty, ... ]
@@ -255,9 +256,11 @@ mod tests {
 
     use mqtt_format::v3::qos::MQualityOfService;
 
-    use crate::server::{subscriptions::TopicFilter, ClientId};
-
-    use super::{ClientInformation, ClientSubscription, SubscriptionTopic};
+    use super::ClientInformation;
+    use super::ClientSubscription;
+    use super::SubscriptionTopic;
+    use crate::server::subscriptions::TopicFilter;
+    use crate::server::ClientId;
 
     macro_rules! build_subs {
         (@topic "#") => {

--- a/tests/check_connecting.rs
+++ b/tests/check_connecting.rs
@@ -7,12 +7,13 @@
 use std::pin::Pin;
 
 use bytes::Bytes;
-use cloudmqtt::{client::MqttClient, client::MqttConnectionParams, error::MqttError};
-use mqtt_format::v3::{
-    connect_return::MConnectReturnCode,
-    packet::{MConnack, MPacket},
-    strings::MString,
-};
+use cloudmqtt::client::MqttClient;
+use cloudmqtt::client::MqttConnectionParams;
+use cloudmqtt::error::MqttError;
+use mqtt_format::v3::connect_return::MConnectReturnCode;
+use mqtt_format::v3::packet::MConnack;
+use mqtt_format::v3::packet::MPacket;
+use mqtt_format::v3::strings::MString;
 use tokio::io::AsyncWriteExt;
 
 #[tokio::test]


### PR DESCRIPTION
This patchset imports rustfmt from the nightly channel, so we get the "don't group imports" functionality in rustfmt.

It then `cargo fmt`s the whole tree.