### PR TITLE
Add gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.rs diff=rust


### PR DESCRIPTION
This patch adds a `.gitattributes` file, so that we can use `git log -L:funcname:file.rs` in the repository.