### PR TITLE
Implement PartialEq for all types

### DIFF
--- a/mqtt-format/src/v5/packets/auth.rs
+++ b/mqtt-format/src/v5/packets/auth.rs
@@ -41,7 +41,7 @@ crate::v5::properties::define_properties! {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 #[doc = crate::v5::util::md_speclink!("_Toc3901217")]
 pub struct MAuth<'i> {
     pub reason: AuthReasonCode,

--- a/mqtt-format/src/v5/packets/connack.rs
+++ b/mqtt-format/src/v5/packets/connack.rs
@@ -115,7 +115,7 @@ define_properties![
     }
 ];
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 #[doc = crate::v5::util::md_speclink!("_Toc3901074")]
 pub struct MConnack<'i> {
     pub session_present: bool,

--- a/mqtt-format/src/v5/packets/connect.rs
+++ b/mqtt-format/src/v5/packets/connect.rs
@@ -33,7 +33,7 @@ use crate::v5::write::WResult;
 use crate::v5::write::WriteMqttPacket;
 use crate::v5::MResult;
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub struct MConnect<'i> {
     pub client_identifier: &'i str,
     pub username: Option<&'i str>,
@@ -208,7 +208,7 @@ impl<'i> MConnect<'i> {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub struct Will<'i> {
     pub properties: ConnectWillProperties<'i>,
     pub topic: &'i str,

--- a/mqtt-format/src/v5/packets/disconnect.rs
+++ b/mqtt-format/src/v5/packets/disconnect.rs
@@ -69,7 +69,7 @@ define_properties! {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 #[doc = crate::v5::util::md_speclink!("_Toc3901205")]
 pub struct MDisconnect<'i> {
     pub reason_code: DisconnectReasonCode,

--- a/mqtt-format/src/v5/packets/pingreq.rs
+++ b/mqtt-format/src/v5/packets/pingreq.rs
@@ -11,7 +11,7 @@ use crate::v5::write::WResult;
 use crate::v5::write::WriteMqttPacket;
 use crate::v5::MResult;
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 #[doc = crate::v5::util::md_speclink!("_Toc3901195")]
 pub struct MPingreq;
 

--- a/mqtt-format/src/v5/packets/pingresp.rs
+++ b/mqtt-format/src/v5/packets/pingresp.rs
@@ -11,7 +11,7 @@ use crate::v5::write::WResult;
 use crate::v5::write::WriteMqttPacket;
 use crate::v5::MResult;
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 #[doc = crate::v5::util::md_speclink!("_Toc3901200")]
 pub struct MPingresp;
 

--- a/mqtt-format/src/v5/packets/puback.rs
+++ b/mqtt-format/src/v5/packets/puback.rs
@@ -41,7 +41,7 @@ define_properties!(
     }
 );
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 #[doc = crate::v5::util::md_speclink!("_Toc3901121")]
 pub struct MPuback<'i> {
     pub packet_identifier: PacketIdentifier,

--- a/mqtt-format/src/v5/packets/pubcomp.rs
+++ b/mqtt-format/src/v5/packets/pubcomp.rs
@@ -33,7 +33,7 @@ crate::v5::properties::define_properties! {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 #[doc = crate::v5::util::md_speclink!("_Toc3901151")]
 pub struct MPubcomp<'i> {
     pub packet_identifier: PacketIdentifier,

--- a/mqtt-format/src/v5/packets/publish.rs
+++ b/mqtt-format/src/v5/packets/publish.rs
@@ -24,7 +24,7 @@ use crate::v5::write::WResult;
 use crate::v5::write::WriteMqttPacket;
 use crate::v5::MResult;
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 #[doc = crate::v5::util::md_speclink!("_Toc3901100")]
 pub struct MPublish<'i> {
     pub duplicate: bool,

--- a/mqtt-format/src/v5/packets/pubrec.rs
+++ b/mqtt-format/src/v5/packets/pubrec.rs
@@ -41,7 +41,7 @@ crate::v5::properties::define_properties![
     }
 ];
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 #[doc = crate::v5::util::md_speclink!("_Toc3901131")]
 pub struct MPubrec<'i> {
     pub packet_identifier: PacketIdentifier,

--- a/mqtt-format/src/v5/packets/pubrel.rs
+++ b/mqtt-format/src/v5/packets/pubrel.rs
@@ -34,7 +34,7 @@ define_properties!(
     }
 );
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 #[doc = crate::v5::util::md_speclink!("_Toc3901141")]
 pub struct MPubrel<'i> {
     pub packet_identifier: PacketIdentifier,

--- a/mqtt-format/src/v5/packets/suback.rs
+++ b/mqtt-format/src/v5/packets/suback.rs
@@ -43,7 +43,7 @@ crate::v5::properties::define_properties! {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 #[doc = crate::v5::util::md_speclink!("_Toc3901171")]
 pub struct MSuback<'i> {
     pub packet_identifier: PacketIdentifier,

--- a/mqtt-format/src/v5/packets/subscribe.rs
+++ b/mqtt-format/src/v5/packets/subscribe.rs
@@ -30,7 +30,7 @@ define_properties! {
     }
 }
 
-#[derive(Debug, num_enum::TryFromPrimitive, num_enum::IntoPrimitive, Clone, Copy)]
+#[derive(Debug, num_enum::TryFromPrimitive, num_enum::IntoPrimitive, Clone, Copy, PartialEq)]
 #[repr(u8)]
 pub enum RetainHandling {
     SendRetainedMessagesAlways = 0,
@@ -38,7 +38,7 @@ pub enum RetainHandling {
     DoNotSendRetainedMessages = 2,
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub struct SubscriptionOptions {
     pub quality_of_service: QualityOfService,
     pub no_local: bool,
@@ -85,7 +85,7 @@ impl SubscriptionOptions {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 #[doc = crate::v5::util::md_speclink!("_Toc3901161")]
 pub struct Subscription<'i> {
     pub topic_filter: &'i str,
@@ -114,6 +114,12 @@ impl<'i> Subscription<'i> {
 
 pub struct Subscriptions<'i> {
     start: &'i [u8],
+}
+
+impl<'i> core::cmp::PartialEq for Subscriptions<'i> {
+    fn eq(&self, other: &Self) -> bool {
+        self.iter().eq(other.iter())
+    }
 }
 
 impl<'i> core::fmt::Debug for Subscriptions<'i> {

--- a/mqtt-format/src/v5/packets/unsuback.rs
+++ b/mqtt-format/src/v5/packets/unsuback.rs
@@ -33,7 +33,7 @@ crate::v5::properties::define_properties! {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 #[doc = crate::v5::util::md_speclink!("_Toc3901187")]
 pub struct MUnsuback<'i> {
     pub packet_identifier: PacketIdentifier,

--- a/mqtt-format/src/v5/packets/unsubscribe.rs
+++ b/mqtt-format/src/v5/packets/unsubscribe.rs
@@ -34,6 +34,12 @@ pub struct Unsubscriptions<'i> {
     start: &'i [u8],
 }
 
+impl<'i> core::cmp::PartialEq for Unsubscriptions<'i> {
+    fn eq(&self, other: &Self) -> bool {
+        self.iter().eq(other.iter())
+    }
+}
+
 impl<'i> core::fmt::Debug for Unsubscriptions<'i> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("Unsubscriptions").finish()
@@ -91,7 +97,7 @@ impl<'i> Iterator for UnsubscriptionsIter<'i> {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub struct Unsubscription<'i> {
     pub topic_filter: &'i str,
 }
@@ -111,7 +117,7 @@ impl<'i> Unsubscription<'i> {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 #[doc = crate::v5::util::md_speclink!("_Toc3901179")]
 pub struct MUnsubscribe<'i> {
     pub packet_identifier: PacketIdentifier,

--- a/mqtt-format/src/v5/properties.rs
+++ b/mqtt-format/src/v5/properties.rs
@@ -60,7 +60,7 @@ macro_rules! define_properties {
         $(
             #[doc = $crate::v5::util::md_speclink!($anker)]
         )?
-        #[derive(Debug)]
+        #[derive(Debug, PartialEq)]
         pub struct $name < $lt > {
             $(
                 $(

--- a/mqtt-format/src/v5/reason_code.rs
+++ b/mqtt-format/src/v5/reason_code.rs
@@ -11,7 +11,7 @@ macro_rules! make_combined_reason_code {
     }) => {
         #[derive(num_enum::TryFromPrimitive, num_enum::IntoPrimitive)]
         #[repr(u8)]
-        #[derive(Debug, Copy, Clone)]
+        #[derive(Debug, Copy, Clone, PartialEq)]
         pub enum $name {
             $( $reason_code_name = <$reason_code_type>::CODE ),*
         }
@@ -42,7 +42,7 @@ pub(crate) use make_combined_reason_code;
 
 macro_rules! define_reason_code {
     ($name:ident => $code:literal) => {
-        #[derive(Debug, Copy, Clone)]
+        #[derive(Debug, Copy, Clone, PartialEq)]
         pub struct $name;
         impl $name {
             pub const CODE: u8 = $code;

--- a/mqtt-format/src/v5/variable_header.rs
+++ b/mqtt-format/src/v5/variable_header.rs
@@ -14,7 +14,7 @@ use super::write::WResult;
 use super::write::WriteMqttPacket;
 use super::MResult;
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct PacketIdentifier(pub u16);
 
 impl PacketIdentifier {
@@ -57,7 +57,7 @@ macro_rules! define_properties {
         $(,)?
     ]) => {
         $(
-            #[derive(Debug)]
+            #[derive(Debug, PartialEq)]
             pub struct $name < $($tylt)? >(pub $(& $lt)? $kind);
 
             impl<'lt $(, $tylt)?> MqttProperties<'lt> for $name < $($tylt)? >
@@ -99,7 +99,7 @@ macro_rules! define_properties {
             }
         )*
 
-        #[derive(Debug)]
+        #[derive(Debug, PartialEq)]
         pub enum Property<'i> {
             $(
                 $name ( $name $(< $tylt >)? ),
@@ -275,6 +275,12 @@ define_properties! {[
 ]}
 
 pub struct UserProperties<'i>(pub &'i [u8]);
+
+impl<'i> core::cmp::PartialEq for UserProperties<'i> {
+    fn eq(&self, other: &Self) -> bool {
+        self.iter().eq(other.iter())
+    }
+}
 
 impl<'i> core::fmt::Debug for UserProperties<'i> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {


### PR DESCRIPTION
Adds `PartialEq` to all packet types and relevant sub-types, so that we can easily implement tests for everything.