### PR TITLE
Do not have Properties write their own IDs

### DIFF
--- a/mqtt-format/clippy.toml
+++ b/mqtt-format/clippy.toml
@@ -1,7 +1,6 @@
 disallowed-methods = [
     "std::result::Result::unwrap",
     "std::option::Option::unwrap",
-    "std::option::Option::expect",
 ]
 
 disallowed-types = [

--- a/mqtt-format/src/v5/properties.rs
+++ b/mqtt-format/src/v5/properties.rs
@@ -148,6 +148,7 @@ macro_rules! define_properties {
 
                 $(
                     if let Some(prop) = self.$prop_name.as_ref() {
+                        $crate::v5::integers::write_variable_u32(buffer, <$prop>::IDENTIFIER).await?;
                         prop.write(buffer).await?;
                     }
                 )*


### PR DESCRIPTION
Previously each prop wrote their own id into the buffer, but did not _read_ it.

This asymmetry is not great and this patch fixes it.

However, UserProperties is different, so it still writes ids for _subsequent_ packets... Nothing much to be done there.