### PR TITLE
Add test for roundtripping u32 write/parse

### DIFF
--- a/mqtt-format/src/v5/integers.rs
+++ b/mqtt-format/src/v5/integers.rs
@@ -211,6 +211,19 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_write_u32() {
+        // step by some prime number
+        for i in (0..268_435_455).step_by(271) {
+            let mut writer = TestWriter { buffer: Vec::new() };
+
+            writer.write_u32(i).await.unwrap();
+
+            let out = parse_u32(&mut Bytes::new(&writer.buffer)).unwrap();
+            assert_eq!(out, i);
+        }
+    }
+
+    #[tokio::test]
     async fn test_write_variable_u32() {
         // step by some prime number
         for i in (0..268_435_455).step_by(271) {

--- a/mqtt-format/src/v5/write.rs
+++ b/mqtt-format/src/v5/write.rs
@@ -36,3 +36,34 @@ pub trait WriteMqttPacket: Send {
         }
     }
 }
+
+#[cfg(test)]
+mod test {
+    use crate::v5::test::TestWriter;
+
+    use super::WriteMqttPacket;
+
+    #[tokio::test]
+    async fn test_write_u32_1() {
+        let mut writer = TestWriter { buffer: Vec::new() };
+        writer.write_u32(1).await.unwrap();
+        assert_eq!(writer.buffer, [0x00, 0x00, 0x00, 0x01]);
+    }
+
+    #[tokio::test]
+    async fn test_write_u32_12() {
+        let mut writer = TestWriter { buffer: Vec::new() };
+        writer.write_u32(12).await.unwrap();
+        assert_eq!(writer.buffer, [0x00, 0x00, 0x00, 12u8.to_be()]);
+    }
+
+    #[tokio::test]
+    async fn test_write_u32_range() {
+        // step by some prime number
+        for i in (0..268_435_455).step_by(271) {
+            let mut writer = TestWriter { buffer: Vec::new() };
+            writer.write_u32(i).await.unwrap();
+            assert_eq!(writer.buffer, i.to_be_bytes());
+        }
+    }
+}

--- a/mqtt-format/src/v5/write.rs
+++ b/mqtt-format/src/v5/write.rs
@@ -29,10 +29,11 @@ pub trait WriteMqttPacket: Send {
     #[inline]
     fn write_u32(&mut self, u: u32) -> impl core::future::Future<Output = WResult<Self>> + Send {
         async move {
-            self.write_byte((u >> 24) as u8).await?;
-            self.write_byte((u >> 16) as u8).await?;
-            self.write_byte((u >> 8) as u8).await?;
-            self.write_byte(u as u8).await
+            let bytes = u.to_be_bytes();
+            self.write_byte(bytes[0]).await?;
+            self.write_byte(bytes[1]).await?;
+            self.write_byte(bytes[2]).await?;
+            self.write_byte(bytes[3]).await
         }
     }
 }


### PR DESCRIPTION
Adds a test for roundtrip testing the `u32` fixed-size implementation.