### PR TITLE
Fix: Do not convert to BE in helper fn

### DIFF
--- a/mqtt-format/src/v5/integers.rs
+++ b/mqtt-format/src/v5/integers.rs
@@ -46,7 +46,7 @@ pub fn parse_u32(input: &mut &Bytes) -> MResult<u32> {
 }
 
 pub async fn write_u32<W: WriteMqttPacket>(buffer: &mut W, u: u32) -> WResult<W> {
-    buffer.write_u32(u.to_be()).await?;
+    buffer.write_u32(u).await?;
     Ok(())
 }
 


### PR DESCRIPTION
The conversion to BE already is in WriteMqttPacket::write_u32(), so converting here is a bug.