### PR TITLE
Fix: PacketIdentifier is not a variable u32 but a u16

### DIFF
--- a/mqtt-format/src/v5/variable_header.rs
+++ b/mqtt-format/src/v5/variable_header.rs
@@ -90,7 +90,7 @@ macro_rules! define_properties {
                 async fn write<W: $crate::v5::write::WriteMqttPacket>(&self, buffer: &mut W)
                     -> $crate::v5::write::WResult<W>
                 {
-                    $crate::v5::integers::write_variable_u32(buffer, $id).await?;
+                    $crate::v5::integers::write_u16(buffer, $id).await?;
                     $writer(buffer, self.0).await?;
                     Ok(())
                 }


### PR DESCRIPTION
From the Spec:

    2.2.1 Packet Identifier

    The Variable Header component of many of the MQTT Control Packet
    types includes a Two Byte Integer Packet Identifier field. These
    MQTT Control Packets are PUBLISH (where QoS > 0), PUBACK, PUBREC,
    PUBREL, PUBCOMP, SUBSCRIBE, SUBACK, UNSUBSCRIBE, UNSUBACK.

See https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901026