### PR TITLE
Dedicated PacketIdentifier{,NonZero} type

### DIFF
--- a/src/client/receive.rs
+++ b/src/client/receive.rs
@@ -4,7 +4,6 @@
 //   file, You can obtain one at http://mozilla.org/MPL/2.0/.
 //
 
-use std::num::NonZeroU16;
 use std::sync::Arc;
 
 use futures::lock::Mutex;
@@ -16,6 +15,7 @@ use yoke::Yoke;
 
 use super::InnerClient;
 use crate::codecs::MqttPacketCodec;
+use crate::packet_identifier::PacketIdentifierNonZero;
 use crate::packets::MqttPacket;
 use crate::packets::MqttWriter;
 use crate::packets::StableBytes;
@@ -148,9 +148,9 @@ async fn handle_pubcomp(
                 tracing::error!("No session state found");
                 todo!()
             };
-            let pident = NonZeroU16::try_from(pubcomp.packet_identifier.0)
+            let pident = PacketIdentifierNonZero::try_from(pubcomp.packet_identifier)
                 .expect("zero PacketIdentifier not valid here");
-            tracing::Span::current().record("packet_identifier", pident);
+            tracing::Span::current().record("packet_identifier", tracing::field::display(pident));
 
             if session_state
                 .outstanding_packets
@@ -189,9 +189,9 @@ async fn handle_puback(
                 todo!()
             };
 
-            let pident = std::num::NonZeroU16::try_from(mpuback.packet_identifier.0)
+            let pident = PacketIdentifierNonZero::try_from(mpuback.packet_identifier)
                 .expect("Zero PacketIdentifier not valid here");
-            tracing::Span::current().record("packet_identifier", pident);
+            tracing::Span::current().record("packet_identifier", tracing::field::display(pident));
 
             if session_state
                 .outstanding_packets
@@ -236,9 +236,9 @@ async fn handle_pubrec(
                 tracing::error!("No session state found");
                 todo!()
             };
-            let pident = NonZeroU16::try_from(pubrec.packet_identifier.0)
+            let pident = PacketIdentifierNonZero::try_from(pubrec.packet_identifier)
                 .expect("zero PacketIdentifier not valid here");
-            tracing::Span::current().record("packet_identifier", pident);
+            tracing::Span::current().record("packet_identifier", tracing::field::display(pident));
 
             if session_state
                 .outstanding_packets

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ pub mod client_identifier;
 mod codecs;
 mod error;
 pub mod keep_alive;
+pub mod packet_identifier;
 pub mod packets;
 pub mod payload;
 mod properties;

--- a/src/packet_identifier.rs
+++ b/src/packet_identifier.rs
@@ -1,0 +1,41 @@
+//
+//   This Source Code Form is subject to the terms of the Mozilla Public
+//   License, v. 2.0. If a copy of the MPL was not distributed with this
+//   file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
+pub struct PacketIdentifier(u16);
+
+impl From<mqtt_format::v5::variable_header::PacketIdentifier> for PacketIdentifier {
+    fn from(value: mqtt_format::v5::variable_header::PacketIdentifier) -> Self {
+        Self(value.0)
+    }
+}
+
+impl From<PacketIdentifier> for mqtt_format::v5::variable_header::PacketIdentifier {
+    fn from(value: PacketIdentifier) -> mqtt_format::v5::variable_header::PacketIdentifier {
+        mqtt_format::v5::variable_header::PacketIdentifier(value.0)
+    }
+}
+
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
+pub struct PacketIdentifierNonZero(std::num::NonZeroU16);
+
+impl TryFrom<mqtt_format::v5::variable_header::PacketIdentifier> for PacketIdentifierNonZero {
+    type Error = (); // TODO
+
+    fn try_from(
+        value: mqtt_format::v5::variable_header::PacketIdentifier,
+    ) -> Result<Self, Self::Error> {
+        std::num::NonZeroU16::try_from(value.0)
+            .map(Self)
+            .map_err(drop) // TODO
+    }
+}
+
+impl From<PacketIdentifierNonZero> for mqtt_format::v5::variable_header::PacketIdentifier {
+    fn from(value: PacketIdentifierNonZero) -> mqtt_format::v5::variable_header::PacketIdentifier {
+        mqtt_format::v5::variable_header::PacketIdentifier(value.0.get())
+    }
+}

--- a/src/packet_identifier.rs
+++ b/src/packet_identifier.rs
@@ -7,6 +7,12 @@
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
 pub struct PacketIdentifier(u16);
 
+impl std::fmt::Display for PacketIdentifier {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
 impl From<mqtt_format::v5::variable_header::PacketIdentifier> for PacketIdentifier {
     fn from(value: mqtt_format::v5::variable_header::PacketIdentifier) -> Self {
         Self(value.0)
@@ -19,8 +25,21 @@ impl From<PacketIdentifier> for mqtt_format::v5::variable_header::PacketIdentifi
     }
 }
 
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct PacketIdentifierNonZero(std::num::NonZeroU16);
+
+impl PacketIdentifierNonZero {
+    #[inline]
+    pub fn get(&self) -> u16 {
+        self.0.get()
+    }
+}
+
+impl std::fmt::Display for PacketIdentifierNonZero {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
 
 impl TryFrom<mqtt_format::v5::variable_header::PacketIdentifier> for PacketIdentifierNonZero {
     type Error = (); // TODO
@@ -37,5 +56,11 @@ impl TryFrom<mqtt_format::v5::variable_header::PacketIdentifier> for PacketIdent
 impl From<PacketIdentifierNonZero> for mqtt_format::v5::variable_header::PacketIdentifier {
     fn from(value: PacketIdentifierNonZero) -> mqtt_format::v5::variable_header::PacketIdentifier {
         mqtt_format::v5::variable_header::PacketIdentifier(value.0.get())
+    }
+}
+
+impl From<std::num::NonZeroU16> for PacketIdentifierNonZero {
+    fn from(value: std::num::NonZeroU16) -> Self {
+        Self(value)
     }
 }


### PR DESCRIPTION
I think we should start using strong types for packet identifiers in the `cloudmqtt` crate. This PR implements it.

Consider this low-prio for now, I am happy to rebase if necessary.