### PR TITLE
Make tracing optional in cloudmqtt-core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -139,6 +139,7 @@ dependencies = [
  "stable_deref_trait",
  "syn",
  "tokio",
+ "tracing",
  "tracing-core",
  "winnow",
  "yoke",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ yoke = { version = "0.8.0", default-features = false }
 
 
 mqtt-format = { version = "0.5.0", path = "crates/mqtt-format", default-features = false }
-cloudmqtt-core = { version = "0.5.0", path = "crates/cloudmqtt-core" }
+cloudmqtt-core = { version = "0.5.0", path = "crates/cloudmqtt-core", default-features = false }
 
 cloudmqtt-workspace-hack = { version = "0.0.0" }
 

--- a/crates/cloudmqtt-core/Cargo.toml
+++ b/crates/cloudmqtt-core/Cargo.toml
@@ -9,8 +9,12 @@ license.workspace = true
 [dependencies]
 mqtt-format = { workspace = true, features = ["mqttv5"] }
 rustc-hash.workspace = true
-tracing = { workspace = true, features = ["attributes"] }
+tracing = { workspace = true, features = ["attributes"], optional = true }
 cloudmqtt-workspace-hack.workspace = true
+
+[features]
+default = ["tracing"]
+tracing = ["dep:tracing"]
 
 [dev-dependencies]
 tracing-subscriber = { workspace = true, features = ["env-filter", "std", "fmt", "ansi", "smallvec"] }

--- a/crates/cloudmqtt-core/Cargo.toml
+++ b/crates/cloudmqtt-core/Cargo.toml
@@ -13,7 +13,7 @@ tracing = { workspace = true, features = ["attributes"], optional = true }
 cloudmqtt-workspace-hack.workspace = true
 
 [features]
-default = ["tracing"]
+default = []
 tracing = ["dep:tracing"]
 
 [dev-dependencies]

--- a/crates/cloudmqtt-core/src/client/mod.rs
+++ b/crates/cloudmqtt-core/src/client/mod.rs
@@ -13,7 +13,8 @@ use mqtt_format::v5::packets::connack::ConnackReasonCode;
 use mqtt_format::v5::packets::connect::MConnect;
 use mqtt_format::v5::qos::QualityOfService;
 use rustc_hash::FxHasher;
-use tracing::trace;
+
+use crate::util::trace;
 
 mod packet_identifier_store;
 pub use self::packet_identifier_store::PacketIdentifierStore;
@@ -218,7 +219,7 @@ where
         self.inner_run(current_time, None, None)
     }
 
-    #[tracing::instrument(
+    #[cfg_attr(feature = "tracing", tracing::instrument(
         skip_all,
         fields(
             current_time = ?current_time,
@@ -226,7 +227,7 @@ where
             to_publish_packet = to_send_packet.is_some()
         ),
         ret
-    )]
+    ))]
     fn inner_run<'p>(
         &mut self,
         current_time: MqttInstant,

--- a/crates/cloudmqtt-core/src/client/packet_identifier_store.rs
+++ b/crates/cloudmqtt-core/src/client/packet_identifier_store.rs
@@ -4,7 +4,7 @@
 //   file, You can obtain one at http://mozilla.org/MPL/2.0/.
 //
 
-use tracing::trace;
+use crate::util::trace;
 
 #[derive(PartialEq, Eq)]
 pub enum PacketIdentifierUsage {

--- a/crates/cloudmqtt-core/src/util.rs
+++ b/crates/cloudmqtt-core/src/util.rs
@@ -3,10 +3,14 @@
 //   License, v. 2.0. If a copy of the MPL was not distributed with this
 //   file, You can obtain one at http://mozilla.org/MPL/2.0/.
 //
-#![cfg_attr(not(test), no_std)]
-#![cfg_attr(not(test), deny(clippy::disallowed_methods))]
-#![cfg_attr(test, allow(clippy::disallowed_methods))]
-#![deny(clippy::disallowed_types)]
 
-pub mod client;
-mod util;
+#[cfg(feature = "tracing")]
+pub use tracing::trace;
+
+#[cfg(not(feature = "tracing"))]
+#[macro_export]
+macro_rules! trace {
+    ($($arg:tt)+) => {};
+}
+#[cfg(not(feature = "tracing"))]
+pub use trace;

--- a/crates/cloudmqtt/Cargo.toml
+++ b/crates/cloudmqtt/Cargo.toml
@@ -13,7 +13,7 @@ license.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-cloudmqtt-core.workspace = true
+cloudmqtt-core = { workspace = true, features = ["tracing"] }
 dashmap.workspace = true
 futures.workspace = true
 mqtt-format = { workspace = true, features = ["yoke"] }

--- a/crates/workspace-hack/Cargo.toml
+++ b/crates/workspace-hack/Cargo.toml
@@ -20,6 +20,7 @@ futures-sink = { version = "0.3" }
 num_enum = { version = "0.7", default-features = false, features = ["std"] }
 stable_deref_trait = { version = "1", default-features = false, features = ["alloc"] }
 tokio = { version = "1", features = ["io-util", "macros", "net", "rt-multi-thread", "test-util"] }
+tracing = { version = "0.1", default-features = false, features = ["attributes"] }
 tracing-core = { version = "0.1", default-features = false, features = ["std"] }
 winnow = { version = "0.7" }
 yoke = { version = "0.8", default-features = false, features = ["alloc", "derive"] }


### PR DESCRIPTION
Moves the `tracing` dependency behind a (default on) feature.