### PR TITLE
Error story

### DIFF
--- a/crates/cloudmqtt/examples/simple.rs
+++ b/crates/cloudmqtt/examples/simple.rs
@@ -12,7 +12,7 @@ async fn main() {
         .await
         .unwrap();
 
-    client.publish(b"What's up", "foo/bar").await;
+    client.publish(b"What's up", "foo/bar").await.unwrap();
 
     client.wait_for_shutdown().await;
 }

--- a/crates/cloudmqtt/examples/simple.rs
+++ b/crates/cloudmqtt/examples/simple.rs
@@ -8,7 +8,9 @@ use cloudmqtt::CloudmqttClient;
 
 #[tokio::main]
 async fn main() {
-    let mut client = CloudmqttClient::new("localhost:1883".to_string()).await;
+    let mut client = CloudmqttClient::new("localhost:1883".to_string())
+        .await
+        .unwrap();
 
     client.publish(b"What's up", "foo/bar").await;
 

--- a/crates/cloudmqtt/examples/subscribe.rs
+++ b/crates/cloudmqtt/examples/subscribe.rs
@@ -9,7 +9,9 @@ use futures::StreamExt;
 
 #[tokio::main]
 async fn main() {
-    let mut client = CloudmqttClient::new("localhost:1883".to_string()).await;
+    let mut client = CloudmqttClient::new("localhost:1883".to_string())
+        .await
+        .unwrap();
 
     let whatsub = client.subscribe("whats/up").await;
     let morestuff = client.subscribe("more/stuff").await;

--- a/crates/cloudmqtt/examples/subscribe.rs
+++ b/crates/cloudmqtt/examples/subscribe.rs
@@ -13,8 +13,8 @@ async fn main() {
         .await
         .unwrap();
 
-    let whatsub = client.subscribe("whats/up").await;
-    let morestuff = client.subscribe("more/stuff").await;
+    let whatsub = client.subscribe("whats/up").await.unwrap();
+    let morestuff = client.subscribe("more/stuff").await.unwrap();
     let mut combined = futures::stream::select(whatsub, morestuff);
 
     while let Some(next_message) = combined.next().await {

--- a/crates/cloudmqtt/examples/subscribe_multi.rs
+++ b/crates/cloudmqtt/examples/subscribe_multi.rs
@@ -19,7 +19,8 @@ async fn main() {
         .with_subscription("more/things")
         .with_subscription("cloudmqtt/rocks")
         .build()
-        .await;
+        .await
+        .unwrap();
 
     while let Some(next_message) = multi_sub.next().await {
         println!("Got: {next_message:?}");

--- a/crates/cloudmqtt/examples/subscribe_multi.rs
+++ b/crates/cloudmqtt/examples/subscribe_multi.rs
@@ -9,7 +9,9 @@ use futures::StreamExt;
 
 #[tokio::main]
 async fn main() {
-    let mut client = CloudmqttClient::new("localhost:1883".to_string()).await;
+    let mut client = CloudmqttClient::new("localhost:1883".to_string())
+        .await
+        .unwrap();
 
     let mut multi_sub = client
         .subscription_builder()

--- a/crates/cloudmqtt/src/client.rs
+++ b/crates/cloudmqtt/src/client.rs
@@ -17,6 +17,7 @@ use tokio_util::codec::FramedWrite;
 use crate::SendUsage;
 use crate::codec::MqttPacket;
 use crate::codec::MqttPacketCodec;
+use crate::error::Error;
 
 fn since(start: Instant) -> MqttInstant {
     MqttInstant::new(start.elapsed().as_secs())
@@ -124,11 +125,11 @@ impl CoreClient {
         }
     }
 
-    pub async fn publish(&self, packet: MqttPacket) {
+    pub async fn publish(&self, packet: MqttPacket) -> Result<(), Error> {
         self.publish_sender
             .send(SendUsage::Publish(packet))
             .await
-            .unwrap();
+            .map_err(|_| Error::InternalChannelClosed)
     }
 
     pub async fn subscribe(&self, packet: MqttPacket) {

--- a/crates/cloudmqtt/src/error.rs
+++ b/crates/cloudmqtt/src/error.rs
@@ -14,4 +14,7 @@ pub enum Error {
 
     #[error("TCP Connectionn failed")]
     TcpConnect(#[source] std::io::Error),
+
+    #[error("Failed writing internal buffer")]
+    WriteBuffer(#[source] crate::codec::MqttWriterError),
 }

--- a/crates/cloudmqtt/src/error.rs
+++ b/crates/cloudmqtt/src/error.rs
@@ -1,0 +1,17 @@
+//
+//   This Source Code Form is subject to the terms of the Mozilla Public
+//   License, v. 2.0. If a copy of the MPL was not distributed with this
+//   file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("Cloud not look up DNS")]
+    DnsLookup(#[source] std::io::Error),
+
+    #[error("DNS request did not return any addresses")]
+    DnsNoAddrs,
+
+    #[error("TCP Connectionn failed")]
+    TcpConnect(#[source] std::io::Error),
+}

--- a/crates/cloudmqtt/src/error.rs
+++ b/crates/cloudmqtt/src/error.rs
@@ -17,4 +17,7 @@ pub enum Error {
 
     #[error("Failed writing internal buffer")]
     WriteBuffer(#[source] crate::codec::MqttWriterError),
+
+    #[error("Internal channel closed")]
+    InternalChannelClosed,
 }

--- a/crates/cloudmqtt/src/lib.rs
+++ b/crates/cloudmqtt/src/lib.rs
@@ -51,7 +51,11 @@ impl CloudmqttClient {
         })
     }
 
-    pub async fn publish(&self, message: impl AsRef<[u8]>, topic: impl AsRef<str>) {
+    pub async fn publish(
+        &self,
+        message: impl AsRef<[u8]>,
+        topic: impl AsRef<str>,
+    ) -> Result<(), Error> {
         self.core_client
             .publish(MqttPacket::new(
                 mqtt_format::v5::packets::MqttPacket::Publish(


### PR DESCRIPTION
This is _the first step_ towards an error story in the codebase. It is not finished yet.

Right now we `unwrap()` and `expect()` all over the place. This introduces an `Error` type and patches some obvious places to bubble errors instead of panicking.

More to come I guess, if you want.